### PR TITLE
Fix #13 - Ignore path suggestions if user does not have access permissions.

### DIFF
--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -32,8 +32,11 @@ class PathsProvider extends Provider
     return [] unless exists
 
     # Is this actually a directory?
-    stat = fs.statSync directory
-    return [] unless stat.isDirectory()
+    try
+      stat = fs.statSync directory
+      return [] unless stat.isDirectory()
+    catch e
+      return []
 
     # Get files
     try
@@ -47,7 +50,10 @@ class PathsProvider extends Provider
       resultPath = path.resolve directory, result
 
       # Check for type
-      stat = fs.statSync resultPath
+      try
+        stat = fs.statSync resultPath
+      catch e
+        continue
       if stat.isDirectory()
         label = "Dir"
         result += "/"


### PR DESCRIPTION
When compiling lists of completions, an uncaught exception may be thrown
if the current user does not have permissions to access a particular
directory.  Such paths frequently occur when typing "/" on a Windows
system. Fixes #13
