### PR TITLE
[Bug fix] Protected files in / cause error

### DIFF
--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -47,7 +47,10 @@ class PathsProvider extends Provider
       resultPath = path.resolve directory, result
 
       # Check for type
-      stat = fs.statSync resultPath
+      try
+        stat = fs.statSync resultPath
+      catch e
+        continue
       if stat.isDirectory()
         label = "Dir"
         result += "/"


### PR DESCRIPTION
On windows when typing / or \ the fs.statSync fails due to the file c:/hiberfil.sys, or others similar, not being readable.
This causes a fatal error.
Putting in this try catch statement allows for this to go wrong and will just move on regardless
Fix for issue #13
