### PR TITLE
Remove all the usages of depricated apis

### DIFF
--- a/lib/autocomplete-paths.coffee
+++ b/lib/autocomplete-paths.coffee
@@ -7,7 +7,7 @@ module.exports =
   autocomplete: null
 
   ###
-   * Registers a SnippetProvider for each editor view
+   * Registers a PathsProvider for each editor view
   ###
   activate: ->
     atom.packages.activatePackage("autocomplete-plus")
@@ -16,22 +16,21 @@ module.exports =
         @registerProviders()
 
   ###
-   * Registers a SnippetProvider for each editor view
+   * Registers a PathsProvider for each editor view
   ###
   registerProviders: ->
-    @editorSubscription = atom.workspaceView.eachEditorView (editorView) =>
-      if editorView.attached and not editorView.mini
-        provider = new PathsProvider editorView
+    @editorSubscription = atom.workspace.observeTextEditors (editor) =>
+      provider = new PathsProvider editor
 
-        @autocomplete.registerProviderForEditorView provider, editorView
+      @autocomplete.registerProviderForEditor provider, editor
 
-        @providers.push provider
+      @providers.push provider
 
   ###
-   * Cleans everything up, unregisters all SnippetProvider instances
+   * Cleans everything up, unregisters all PathsProvider instances
   ###
   deactivate: ->
-    @editorSubscription?.off()
+    @editorSubscription?.dispose()
     @editorSubscription = null
 
     @providers.forEach (provider) =>

--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -10,7 +10,7 @@ class PathsProvider extends Provider
   wordRegex: /[a-zA-Z0-9\.\/_-]*\/[a-zA-Z0-9\.\/_-]*/g
   exclusive: true
   buildSuggestions: ->
-    selection = @editor.getSelection()
+    selection = @editor.getLastSelection()
     prefix = @prefixOfSelection selection
     return unless prefix.length
 
@@ -86,7 +86,7 @@ class PathsProvider extends Provider
     @editor.setSelectedBufferRange [startPosition, [startPosition.row, startPosition.column + suffixLength]]
 
     setTimeout(=>
-      @editorView.trigger "autocomplete-plus:activate"
+      atom.commands.dispatch atom.views.getView(@editor), "autocomplete-plus:activate"
     , 100)
 
     return false # Don't fall back to the default behavior

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "underscore-plus": "~1.1.2",
-    "autocomplete-plus": "git://github.com/saschagehlich/autocomplete-plus.git",
+    "autocomplete-plus": "git://github.com/atom-community/autocomplete-plus.git",
     "fuzzaldrin": "~1.0.0"
   }
 }

--- a/spec/issues/11-spec.coffee
+++ b/spec/issues/11-spec.coffee
@@ -1,39 +1,35 @@
-{WorkspaceView} = require "atom"
-
 describe "Issue 11", ->
-	[activationPromise, completionDelay] = []
+  [activationPromise, completionDelay, editor, editorView] = []
 
-	beforeEach ->
-		# Enable live autocompletion
-		atom.config.set "autocomplete-plus.enableAutoActivation", true
+  beforeEach ->
+    # Enable live autocompletion
+    atom.config.set "autocomplete-plus.enableAutoActivation", true
 
-		# Set the completion delay
-		completionDelay = 100
-		atom.config.set "autocomplete-plus.autoActivationDelay", completionDelay
-		completionDelay += 100 # Rendering delay
+    # Set the completion delay
+    completionDelay = 100
+    atom.config.set "autocomplete-plus.autoActivationDelay", completionDelay
+    completionDelay += 100 # Rendering delay
 
-		# Open an editor which has no path
-		atom.workspaceView = new WorkspaceView
-		atom.workspaceView.openSync()
-		atom.workspaceView.simulateDomAttachment()
-		
-		activationPromise = atom.packages.activatePackage("autocomplete-paths")
-			.then => atom.packages.activatePackage("autocomplete-plus")
+    waitsForPromise ->
+      activationPromise = atom.packages.activatePackage("autocomplete-paths")
+        .then => atom.packages.activatePackage("autocomplete-plus")
 
-	it "Works in editors which have no path", ->
-		waitsForPromise ->
-			activationPromise
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
 
-		runs ->
-			editorView = atom.workspaceView.getActiveView()
-			editorView.attachToDom()
-			editor = editorView.getEditor()
+    waitsForPromise -> atom.workspace.open().then (e) ->
+      editor = e
 
-			expect(editorView.find(".autocomplete-plus")).not.toExist()
+    runs ->
+      editorView = atom.views.getView(editor)
 
-			editor.moveCursorToBottom()
-			editor.insertText "/"
+  it "Works in editors which have no path", ->
+    runs ->
+      expect(editorView.querySelector(".autocomplete-plus")).not.toExist()
 
-			advanceClock completionDelay
+      editor.moveToBottom()
+      editor.insertText "/"
 
-			expect(editorView.find(".autocomplete-plus")).not.toExist()
+      advanceClock completionDelay
+
+      expect(editorView.querySelector(".autocomplete-plus")).not.toExist()


### PR DESCRIPTION
remove depricated apis to sync up with atom-community/autocomplete-plus/pull/155
