### PR TITLE
Better support for Windows paths

### DIFF
--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -7,7 +7,7 @@ module.exports =
 class PathsProvider
   id: 'autocomplete-paths-pathsprovider'
   selector: '*'
-  wordRegex: /[a-zA-Z0-9\.\/_-]*\/[a-zA-Z0-9\.\/_-]*/g
+  wordRegex: /(?:[a-zA-Z]:)?[a-zA-Z0-9./\\_-]*(?:\/|\\\\?)[a-zA-Z0-9./\\_-]*/g
   cache: []
 
   requestHandler: (options = {}) =>
@@ -55,7 +55,7 @@ class PathsProvider
 
     prefixPath = path.resolve(basePath, prefix)
 
-    if prefix.endsWith('/')
+    if prefix.match(/[/\\]$/)
       directory = prefixPath
       prefix = ''
     else
@@ -89,7 +89,6 @@ class PathsProvider
         continue
       if stat.isDirectory()
         label = 'Dir'
-        result += path.sep
       else if stat.isFile()
         label = 'File'
       else

--- a/spec/autocomplete-paths-spec.coffee
+++ b/spec/autocomplete-paths-spec.coffee
@@ -72,7 +72,7 @@ describe 'Autocomplete Snippets', ->
 
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('linkeddir/')
+        expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('linkeddir')
         expect(editorView.querySelector('.autocomplete-plus span.completion-label')).toHaveText('Dir')
 
     it 'does not crash when typing an invalid folder', ->
@@ -93,7 +93,7 @@ describe 'Autocomplete Snippets', ->
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
         editor.moveToBottom()
-        editor.insertText(c) for c in './linkedir'
+        editor.insertText(c) for c in './linkeddir'
 
         advanceClock(completionDelay)
 
@@ -101,8 +101,11 @@ describe 'Autocomplete Snippets', ->
         autocompleteManager.displaySuggestions.calls.length is 1
 
       runs ->
-        # Select linkeddir/
+        # Select linkeddir
         atom.commands.dispatch(editorView, 'autocomplete-plus:confirm')
+        advanceClock(completionDelay)
+
+        editor.insertText('/')
         advanceClock(completionDelay)
 
       waitsFor ->


### PR DESCRIPTION
This PR adds better support for the Windows path separator `\` as well as Windows drive prefixes (e.g `C:`). It even works with "escaped" backslashes (e.g. `C:\\Users\\`).

There is one significant change however—it no longer adds the path separator to the end of its completions. So `lib/` is now just `lib` and `C:\Users\` is now just `C:\Users`.

This isn't really that much of a change considering that autocomplete-paths is, [according to its code][L106], supposed to show a new list of suggestions immediately after confirming the previous. This isn't working on my Windows or Linux box and the spec is failing. So you have to either start typing the next few letters of the next file or folder you want, or press <kbd>Backspace</kbd> then <kbd>/</kbd> to see more suggestions.

This update removes that extra slash, so you're required to type it yourself. This is actually a good thing in most cases since the path separator you use is going to depend upon language or framework rather than the computer you're currently using.

All questions, comments, concerns, and kudos are welcome.

[L106]: https://github.com/atom-community/autocomplete-paths/blob/4f56ff25e30365a7d8a2c7f2b9d1275d5294b2bd/lib/paths-provider.coffee#L106