### PR TITLE
Use latest query selector for right-label in tests

### DIFF
--- a/spec/autocomplete-paths-spec.coffee
+++ b/spec/autocomplete-paths-spec.coffee
@@ -73,7 +73,7 @@ describe 'Autocomplete Snippets', ->
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
         expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('linkeddir')
-        expect(editorView.querySelector('.autocomplete-plus span.completion-label')).toHaveText('Dir')
+        expect(editorView.querySelector('.autocomplete-plus span.right-label')).toHaveText('Dir')
 
     it 'does not crash when typing an invalid folder', ->
       runs ->
@@ -132,4 +132,4 @@ describe 'Autocomplete Snippets', ->
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
         expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('.gitkeep')
-        expect(editorView.querySelector('.autocomplete-plus span.completion-label')).toHaveText('File')
+        expect(editorView.querySelector('.autocomplete-plus span.right-label')).toHaveText('File')


### PR DESCRIPTION
Tests were failing because the class name on the "right labels" was changed from `completion-label` to `right-label`.
