### PR TITLE
Add normalizeSlashes option

### DIFF
--- a/lib/autocomplete-paths.coffee
+++ b/lib/autocomplete-paths.coffee
@@ -2,6 +2,13 @@ module.exports =
   provider: null
   ready: false
 
+  config:
+    normalizeSlashes:
+      title: 'Normalize Slashes'
+      description: 'Converts backslashes to forward slashes'
+      type: 'boolean'
+      default: false
+
   activate: ->
     @ready = true
 

--- a/lib/paths-provider.coffee
+++ b/lib/paths-provider.coffee
@@ -1,5 +1,6 @@
 {Range}  = require('atom')
 fuzzaldrin = require('fuzzaldrin')
+slash = require('slash')
 path = require('path')
 fs = require('fs')
 
@@ -93,6 +94,9 @@ class PathsProvider
         label = 'File'
       else
         continue
+
+      if atom.config.get('autocomplete-paths.normalizeSlashes')
+        result = slash(result)
 
       suggestion =
         word: result

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "underscore-plus": ">=1.1.2",
-    "fuzzaldrin": ">=1.0.0"
+    "fuzzaldrin": ">=1.0.0",
+    "slash": "^1.0.0"
   },
   "devDependencies": {
     "coffeelint": "^1.8.1"


### PR DESCRIPTION
My colleagues use Windows and are reporting that they get backslashes in their completions. In JS and friends, this is rather annoying. This PR introduces an option to run the completions through `slash()`.