### PR TITLE
Fix spec suit

### DIFF
--- a/spec/autocomplete-paths-spec.coffee
+++ b/spec/autocomplete-paths-spec.coffee
@@ -4,9 +4,9 @@ describe 'Autocomplete Snippets', ->
   [workspaceElement, completionDelay, editor, editorView, pathsMain, autocompleteMain, autocompleteManager] = []
 
   testConfig = {
-    "autocomplete-plus.enableAutoActivation": true
-    "autocomplete-plus.minimumWordLength": -1
-    "autocomplete-plus.autoActivationDelay": 100
+    'autocomplete-plus.enableAutoActivation': true
+    'autocomplete-plus.minimumWordLength': -1
+    'autocomplete-plus.autoActivationDelay': 100
   }
 
   beforeEach ->
@@ -19,7 +19,7 @@ describe 'Autocomplete Snippets', ->
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
 
-      autocompletePlusPkg = atom.packages.loadPackage 'autocomplete-plus'
+      autocompletePlusPkg = atom.packages.loadPackage('autocomplete-plus')
       autocompletePlusPkg.requireMainModule()
       autocompleteMain = autocompletePlusPkg.mainModule
 

--- a/spec/autocomplete-paths-spec.coffee
+++ b/spec/autocomplete-paths-spec.coffee
@@ -3,19 +3,32 @@ path = require('path')
 describe 'Autocomplete Snippets', ->
   [workspaceElement, completionDelay, editor, editorView, pathsMain, autocompleteMain, autocompleteManager] = []
 
+  testConfig = {
+    "autocomplete-plus.enableAutoActivation": true
+    "autocomplete-plus.minimumWordLength": -1
+    "autocomplete-plus.autoActivationDelay": 100
+  }
+
   beforeEach ->
     runs ->
-      # Set to live completion
-      atom.config.set('autocomplete-plus.enableAutoActivation', true)
-      # Set the completion delay
+      Object.keys(testConfig).forEach (key) ->
+        atom.config.set(key, testConfig[key])
+
       completionDelay = 100
-      atom.config.set('autocomplete-plus.autoActivationDelay', completionDelay)
       completionDelay += 100 # Rendering delay
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
-      autocompleteMain = atom.packages.loadPackage('autocomplete-plus').mainModule
+
+      autocompletePlusPkg = atom.packages.loadPackage 'autocomplete-plus'
+      autocompletePlusPkg.requireMainModule()
+      autocompleteMain = autocompletePlusPkg.mainModule
+
       spyOn(autocompleteMain, 'consumeProvider').andCallThrough()
-      pathsMain = atom.packages.loadPackage('autocomplete-paths').mainModule
+
+      pathPkg = atom.packages.loadPackage('autocomplete-paths')
+      pathPkg.requireMainModule()
+      pathsMain = pathPkg.mainModule
+
       spyOn(pathsMain, 'provide').andCallThrough()
 
     waitsForPromise ->
@@ -72,8 +85,8 @@ describe 'Autocomplete Snippets', ->
 
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('linkeddir')
-        expect(editorView.querySelector('.autocomplete-plus span.completion-label')).toHaveText('Dir')
+        expect(editorView.querySelector('.autocomplete-plus .word')).toHaveText('linkeddir')
+        expect(editorView.querySelector('.autocomplete-plus .right-label')).toHaveText('Dir')
 
     it 'does not crash when typing an invalid folder', ->
       runs ->
@@ -131,5 +144,5 @@ describe 'Autocomplete Snippets', ->
 
       runs ->
         expect(editorView.querySelector('.autocomplete-plus')).toExist()
-        expect(editorView.querySelector('.autocomplete-plus span.word')).toHaveText('.gitkeep')
-        expect(editorView.querySelector('.autocomplete-plus span.completion-label')).toHaveText('File')
+        expect(editorView.querySelector('.autocomplete-plus .word')).toHaveText('.gitkeep')
+        expect(editorView.querySelector('.autocomplete-plus .right-label')).toHaveText('File')

--- a/spec/issues/11-spec.coffee
+++ b/spec/issues/11-spec.coffee
@@ -12,7 +12,7 @@ describe 'Issue 11', ->
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
 
-      autocompletePlusPkg = atom.packages.loadPackage 'autocomplete-plus'
+      autocompletePlusPkg = atom.packages.loadPackage('autocomplete-plus')
       autocompletePlusPkg.requireMainModule()
       autocompleteMain = autocompletePlusPkg.mainModule
 

--- a/spec/issues/11-spec.coffee
+++ b/spec/issues/11-spec.coffee
@@ -11,9 +11,17 @@ describe 'Issue 11', ->
       completionDelay += 100 # Rendering delay
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
-      autocompleteMain = atom.packages.loadPackage('autocomplete-plus').mainModule
+
+      autocompletePlusPkg = atom.packages.loadPackage 'autocomplete-plus'
+      autocompletePlusPkg.requireMainModule()
+      autocompleteMain = autocompletePlusPkg.mainModule
+
       spyOn(autocompleteMain, 'consumeProvider').andCallThrough()
-      pathsMain = atom.packages.loadPackage('autocomplete-paths').mainModule
+
+      pathPkg = atom.packages.loadPackage('autocomplete-paths')
+      pathPkg.requireMainModule()
+      pathsMain = pathPkg.mainModule
+
       spyOn(pathsMain, 'provide').andCallThrough()
 
     waitsForPromise ->

--- a/spec/large-file-spec.coffee
+++ b/spec/large-file-spec.coffee
@@ -11,9 +11,17 @@ describe 'Autocomplete Snippets', ->
       completionDelay += 100 # Rendering delay
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
-      autocompleteMain = atom.packages.loadPackage('autocomplete-plus').mainModule
+
+      autocompletePlusPkg = atom.packages.loadPackage 'autocomplete-plus'
+      autocompletePlusPkg.requireMainModule()
+      autocompleteMain = autocompletePlusPkg.mainModule
+
       spyOn(autocompleteMain, 'consumeProvider').andCallThrough()
-      pathsMain = atom.packages.loadPackage('autocomplete-paths').mainModule
+
+      pathPkg = atom.packages.loadPackage('autocomplete-paths')
+      pathPkg.requireMainModule()
+      pathsMain = pathPkg.mainModule
+
       spyOn(pathsMain, 'provide').andCallThrough()
 
     waitsForPromise ->

--- a/spec/large-file-spec.coffee
+++ b/spec/large-file-spec.coffee
@@ -12,7 +12,7 @@ describe 'Autocomplete Snippets', ->
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
 
-      autocompletePlusPkg = atom.packages.loadPackage 'autocomplete-plus'
+      autocompletePlusPkg = atom.packages.loadPackage('autocomplete-plus')
       autocompletePlusPkg.requireMainModule()
       autocompleteMain = autocompletePlusPkg.mainModule
 


### PR DESCRIPTION
- `loadPackage()` only loads the keymaps, menus, stylesheets, etc.
  To load the mainModule `.requireMainModule()` has to be called.
- The css class `.completion-label` was renamed to `.right-label`.
- Set the config in one place.
- Set minimumWordLength config in advanced for #101.