### PR TITLE
Include prefix config for unnamed ES import

### DIFF
--- a/lib/config/default-scopes.js
+++ b/lib/config/default-scopes.js
@@ -5,6 +5,7 @@ export default [
     scopes: ['source.js', 'source.js.jsx', 'source.coffee', 'source.coffee.jsx', 'source.ts', 'source.tsx'],
     prefixes: [
       'import\\s+.*?from\\s+[\'"]', // import foo from './foo'
+      'import\s+[\'"]', // import './foo'
       'require\\([\'"]', // require('./foo')
       'define\\(\\[?[\'"]' // define(['./foo']) or define('./foo')
     ],


### PR DESCRIPTION
The current config matches `import foo from './foo'` but not `import './foo'` (importing only for side effects)