### PR TITLE
Project relative path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ well as the CommonJS `require()` syntax and the RequireJS `define()` syntax:
   extensions: ['js', 'jsx', 'ts', 'coffee'], // Only shows JS / TS / Coffee files
   relative: true, // Inserts relative paths only - defaults to true
   includeCurrentDirectory: true, // Include './' in path - defaults to true
+  projectRelativePath: false, // Includes full relative path starting after the project directory
   replaceOnInsert: [ // Replaces the file extensions on insert
     ['.jsx?$', ''],
     ['.ts$', ''],

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -150,7 +150,8 @@ export default class PathsProvider extends EventEmitter {
     let suggestions = files.map(pathName => {
       const normalizeSlashes = atom.config.get('autocomplete-paths.normalizeSlashes')
 
-      let displayText = atom.project.relativizePath(pathName)[1]
+      const projectRelativePath = atom.project.relativizePath(pathName)[1]
+      let displayText = projectRelativePath
       if (directoryGiven) {
         displayText = path.relative(requestedDirectoryPath, pathName)
       }
@@ -168,6 +169,10 @@ export default class PathsProvider extends EventEmitter {
             pathName = `./${pathName}`
           }
         }
+      }
+
+      if (scope.projectRelativePath) {
+        pathName = projectRelativePath
       }
 
       // Replace stuff if necessary

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -180,8 +180,8 @@ export default class PathsProvider extends EventEmitter {
         let originalPathName = pathName
         scope.replaceOnInsert.forEach(([from, to]) => {
           const regex = new RegExp(from)
-          if (regex.test(originalPathName)) {
-            pathName = originalPathName.replace(regex, to)
+          if (regex.test(pathName)) {
+            pathName = pathName.replace(regex, to)
           }
         })
       }


### PR DESCRIPTION
This introduces a new config option for the scopes to allow inserting of a file path relative to the project path.

This is useful for projects relying on the root project path (via `NODE_PATH`) or webpack-enabled projects (via [`resolve.modules`](https://webpack.js.org/configuration/resolve/#resolve-modules)).