### PR TITLE
Show file count in the status bar

### DIFF
--- a/lib/autocomplete-paths.js
+++ b/lib/autocomplete-paths.js
@@ -76,17 +76,26 @@ export default {
     }
     if (this._statusBarTile) return
 
-    const statusBarElement = document.createElement('autocomplete-paths-status-bar')
-    statusBarElement.innerHTML = 'Rebuilding paths cache...'
-    this._statusBarTile = this._statusBar.addRightTile({ item: statusBarElement, priority: 100 })
+    this._statusBarElement = document.createElement('autocomplete-paths-status-bar')
+    this._statusBarElement.innerHTML = 'Rebuilding paths cache...'
+    this._statusBarTile = this._statusBar.addRightTile({
+      item: this._statusBarElement,
+      priority: 100
+    })
+    this._statusBarInterval = setInterval(() => {
+      const fileCount = this._provider.fileCount;
+      this._statusBarElement.innerHTML = `Rebuilding paths cache... ${fileCount} files`;
+    }, 500)
   },
 
   /**
    * Hides the status bar tile
    */
   _hideStatusBarTile () {
+    clearInterval(this._statusBarInterval)
     this._statusBarTile && this._statusBarTile.destroy()
     this._statusBarTile = null
+    this._statusBarElement = null
   },
 
   getProvider: function () {

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -265,6 +265,13 @@ export default class PathsProvider extends EventEmitter {
     return atom.config.get('autocomplete-paths.suggestionPriority')
   }
 
+  get fileCount() {
+    return atom.project.getDirectories().reduce((accumulated, directory) => {
+      const filePaths = this._pathsCache.getFilePathsForProjectDirectory(directory)
+      return accumulated + filePaths.length;
+    }, 0)
+  }
+
   /**
    * Disposes this provider
    */


### PR DESCRIPTION
This adds the current file count in the status bar element when the initial paths cache is being built.

This is useful for projects with 10000+ files, to get a sense of what progress is done.