### PR TITLE
Support additional ignore patterns

### DIFF
--- a/lib/autocomplete-paths.js
+++ b/lib/autocomplete-paths.js
@@ -22,7 +22,8 @@ export default {
       'core.ignoredNames',
       'core.excludeVcsIgnoredPaths',
       'autocomplete-paths.ignoreSubmodules',
-      'autocomplete-paths.ignoredNames'
+      'autocomplete-paths.ignoredNames',
+      'autocomplete-paths.ignoredPatterns'
     ]
     cacheOptions.forEach(cacheOption => {
       this.subscriptions.add(atom.config.observe(cacheOption, value => {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -28,6 +28,14 @@ const options = {
     default: false,
     description: 'Ignore submodule directories.'
   },
+  ignoredPatterns: {
+    type: 'array',
+    default: [],
+    items: {
+      type: 'string'
+    },
+    description: 'Ignore additional file path patterns.'
+  },
   scopes: {
     type: 'array',
     default: [],

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -43,6 +43,15 @@ export default class PathsCache extends EventEmitter {
         ignored = ignored || minimatch(path, ignoredName, { matchBase: true, dot: true })
       })
     }
+
+    const ignoredPatterns = atom.config.get('autocomplete-paths.ignoredPatterns')
+    if (ignoredPatterns) {
+      ignoredPatterns.forEach(ignoredPattern => {
+        if (ignored) return
+        ignored = ignored || minimatch(path, ignoredPattern, { dot: true })
+      })
+    }
+
     return ignored
   }
 

--- a/spec/autocomplete-paths-spec.js
+++ b/spec/autocomplete-paths-spec.js
@@ -22,6 +22,7 @@ describe('autocomplete-paths', () => {
   beforeEach(() => {
     atom.config.set('autocomplete-plus.enableAutoActivation', true)
     atom.config.set('autocomplete-plus.autoActivationDelay', COMPLETION_DELAY)
+    atom.config.set('autocomplete-paths.ignoredPatterns', ['**/tests'])
 
     let workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
@@ -51,7 +52,7 @@ describe('autocomplete-paths', () => {
     })
     waitsForPromise(() => getSuggestions()
       .then((suggestions) => {
-        expect(suggestions).toHaveLength(2)
+        expect(suggestions).toHaveLength(4)
       }))
   })
 
@@ -63,9 +64,11 @@ describe('autocomplete-paths', () => {
     })
     waitsForPromise(() => getSuggestions()
       .then((suggestions) => {
-        expect(suggestions).toHaveLength(2)
+        expect(suggestions).toHaveLength(4)
         expect(suggestions[0].displayText).toBe('somedir/testfile.js')
-        expect(suggestions[1].displayText).toBe('somedir/testdir/nested-test-file.js')
+        expect(suggestions[1].displayText).toBe('linkeddir/testfile.js')
+        expect(suggestions[2].displayText).toBe('somedir/testdir/nested-test-file.js')
+        expect(suggestions[3].displayText).toBe('linkeddir/testdir/nested-test-file.js')
       }))
   })
 


### PR DESCRIPTION
This adds a configuration option for additional ignore patterns to be used to filter out files from the cache.

This is useful for test files, since those are rarely used as imports and would simply pollute the file cache.