### PR TITLE
Support project change

### DIFF
--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -14,6 +14,8 @@ export default class PathsCache extends EventEmitter {
   constructor () {
     super()
 
+    this._projectChangeWatcher = atom.project.onDidChangePaths(() => this.rebuildCache())
+
     this._repositories = []
     this._filePathsByProjectDirectory = new Map()
     this._filePathsByDirectory = new Map()
@@ -270,7 +272,7 @@ export default class PathsCache extends EventEmitter {
   /**
    * Disposes this PathsCache
    */
-  dispose () {
+  dispose(isPackageDispose) {
     this._fileWatchersByDirectory.forEach((watcher, directory) => {
       watcher.dispose()
     })
@@ -281,6 +283,10 @@ export default class PathsCache extends EventEmitter {
     if (this._projectWatcher) {
       this._projectWatcher.dispose()
       this._projectWatcher = null
+    }
+    if (isPackageDispose && this._projectChangeWatcher) {
+      this._projectChangeWatcher.dispose()
+      this._projectChangeWatcher = null
     }
   }
 

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -283,7 +283,7 @@ export default class PathsProvider extends EventEmitter {
   dispose () {
     this._pathsCache.removeListener('rebuild-cache', this._onRebuildCache)
     this._pathsCache.removeListener('rebuild-cache-done', this._onRebuildCacheDone)
-    this._pathsCache.dispose()
+    this._pathsCache.dispose(true)
   }
 }
 


### PR DESCRIPTION
Trigger a cache rebuild when the project has been changed in the workspace (top level project directories have changed).