### PR TITLE
Ignore built-in scopes support

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -36,6 +36,11 @@ const options = {
     },
     description: 'Ignore additional file path patterns.'
   },
+  ignoreBuiltinScopes: {
+    type: 'boolean',
+    default: false,
+    description: 'Ignore built-in scopes and use only scopes from user configuration.'
+  },
   scopes: {
     type: 'array',
     default: [],

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -29,8 +29,11 @@ export default class PathsProvider extends EventEmitter {
    * Reloads the scopes
    */
   reloadScopes () {
-    this._scopes = atom.config.get('autocomplete-paths.scopes') || []
-    this._scopes = this._scopes.slice(0).concat(DefaultScopes)
+    this._scopes = atom.config.get('autocomplete-paths.scopes').slice(0) || []
+
+    if (!atom.config.get('autocomplete-paths.ignoreBuiltinScopes')) {
+      this._scopes = this._scopes.concat(DefaultScopes)
+    }
 
     for (var key in OptionScopes) {
       if (atom.config.get(`autocomplete-paths.${key}`)) {


### PR DESCRIPTION
This allows a user to ignore built-in scopes if they overlap with its own configured scopes.

It fixes issues like the one shown in the demo at https://github.com/atom-community/autocomplete-paths/pull/158#issuecomment-329543937