### PR TITLE
Add javascript to default scopes to support tree-sitter syntax

### DIFF
--- a/lib/config/default-scopes.js
+++ b/lib/config/default-scopes.js
@@ -2,7 +2,7 @@
 
 export default [
   {
-    scopes: ['source.js', 'source.js.jsx', 'source.coffee', 'source.coffee.jsx', 'source.ts', 'source.tsx'],
+    scopes: ['source.js', 'source.js.jsx', 'source.coffee', 'source.coffee.jsx', 'source.ts', 'source.tsx', 'javascript'],
     prefixes: [
       'import\\s+.*?from\\s+[\'"]', // import foo from './foo'
       'import\\s+[\'"]', // import './foo'


### PR DESCRIPTION
After enabling the tree-sitter syntax highlighting, I noticed this package stopped working. Based on what I could tell, it's because tree-sitter adds a different scope to the editor. This adds `javascript` to the default scopes so that we get support in JS files when using tree-sitter syntax highlighting.

cc: @maxbrunsfeld 