### PR TITLE
Add normalized slashes for projectRelativePath

### DIFF
--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -175,7 +175,7 @@ export default class PathsProvider extends EventEmitter {
       }
 
       if (scope.projectRelativePath) {
-        pathName = projectRelativePath
+        pathName = slash(projectRelativePath)
       }
 
       // Replace stuff if necessary


### PR DESCRIPTION
So far on windows the backslashes are not changed to forward slashes if projectRelativePath is set in a scope.