### PR TITLE
handle when a project is not git repository

### DIFF
--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -87,7 +87,8 @@ export default class PathsCache extends EventEmitter {
     for (let i = 0; i < projectNum; i++) {
       repositoriesP[i] = atom.project.repositoryForDirectory(this._projectDirectories[i])
     }
-    this._repositories = await Promise.all(repositoriesP)
+    const repositories = await Promise.all(repositoriesP)
+    this._repositories = repositories.filter(r => r !== null) // filter out non-repository directories
   }
 
   /**


### PR DESCRIPTION
when a project is not a git repository, `atom.project.repositoryForDirectory` will return `null`