### PR TITLE
fix: try find first

### DIFF
--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -223,13 +223,14 @@ export default class PathsCache extends EventEmitter {
     this._cancelled = false
     this.emit('rebuild-cache')
 
-    return execPromise('find --version')
-      .then(
-        // `find` is available
-        () => this._buildInitialCacheWithFind(),
+    if (process.platform === 'win32') {
+      return this._buildInitialCache()
+    } else {
+      return this._buildInitialCacheWithFind().catch(
         // `find` is not available
         () => this._buildInitialCache()
       )
+    }
   }
 
   /**


### PR DESCRIPTION
fixes #241 

Try `find` first and if it fails for any reason gets paths the other way.

closes #243 
