### PR TITLE
fix: replace await-spawn with native exec

### DIFF
--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -4,11 +4,10 @@
 import { EventEmitter } from 'events'
 import fs from 'fs'
 import gitIgnoreParser from 'git-ignore-parser';
-import spawn from 'await-spawn';
 import { compact } from 'underscore'
 import minimatch from 'minimatch'
 import { Directory, File } from 'atom'
-import { union } from './utils'
+import { union, exec, MAX_STRING_LENGTH } from './utils'
 
 export default class PathsCache extends EventEmitter {
   constructor () {
@@ -224,7 +223,7 @@ export default class PathsCache extends EventEmitter {
     this._cancelled = false
     this.emit('rebuild-cache')
 
-    return spawn('find',  ['--version'])
+    return exec('find',  ['--version'], { maxBuffer: MAX_STRING_LENGTH })
       .then(
         // `find` is available
         () => this._buildInitialCacheWithFind(),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,13 @@
 'use babel'
 
+// exec
+import { exec as execRaw } from 'child_process'
+import { promisify } from 'util'
+export const exec = promisify(execRaw)
+import { constants } from 'buffer'
+export const MAX_STRING_LENGTH = constants.MAX_STRING_LENGTH
+
+
 // fast merge function
 // https://uilicious.com/blog/javascript-array-push-is-945x-faster-than-array-concat/
 export function merge(arr1: Array<any>, arr2: Array<any>) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     }
   },
   "dependencies": {
-    "await-spawn": "^4.0.1",
     "fuzzaldrin-plus-fast": "^1.2.4",
     "git-ignore-parser": "^0.0.2",
     "minimatch": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,13 +2439,6 @@ available-typed-arrays@^1.0.0, available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
-await-spawn@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/await-spawn/-/await-spawn-4.0.1.tgz#71bb2433bc5be52b9bfd0154435d5e063e0ba4a5"
-  integrity sha512-cQSpdH79ktTdsMjUuUvyhdIYbXArynlV5jvHY8FPWXdwF5UGyrVaHCQxo/Iw5DbSQx2Ha3EOS+cy41sup+AkiQ==
-  dependencies:
-    bl "^4.0.3"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2583,15 +2576,6 @@ bindings@~1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bl@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
-  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
@@ -6076,7 +6060,7 @@ react-refresh@^0.9.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==


### PR DESCRIPTION
- Runtime performance benefits
- Reduces the bundle size from 95 KB to 50 KB
