### PR TITLE
feat: use fast-glob to find the paths asynchronously in parallel 

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -35,7 +35,7 @@ export const config = {
     items: {
       type: "string",
     },
-    description: "Ignore additional file path patterns.",
+    description: "Ignore additional **glob** or file path patterns.",
   },
   ignoreBuiltinScopes: {
     type: "boolean",

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -15,6 +15,14 @@ export function posixifyPathNormalized(givenPath) {
   return posixifyPath(givenPath).replace(/[/\\]$/, "")
 }
 /**
+ * A line starting with # serves as a comment.
+ * Put a backslash ("\") in front of the first hash for patterns that begin with a hash.
+ */
+function isGitIgnoreComment(pattern) {
+  return pattern[0] === "#"
+}
+
+/**
  * Trailing spaces should be removed unless they are quoted with backslash ("\ ").
  */
 function trimTrailingWhitespace(str) {

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -1,0 +1,8 @@
+import path from "path"
+/** Converts given path to Posix (replacing \\ with /)
+ * @param {string} givenPath   Path to convert
+ * @returns {string}          Converted filepath
+ */
+export function posixifyPath(givenPath) {
+  return path.normalize(givenPath).replace(/\\/g, "/")
+}

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -21,6 +21,15 @@ export function posixifyPathNormalized(givenPath) {
 }
 
 /**
+ * @param {string} givenPath The given path to be globified
+ * @param {string} givenDirectory [process.cwd()]  The cwd to use to resolve relative pathnames
+ * @returns {string | [string, string]} The glob path or the file path itself
+ */
+export function globifyPath(givenPath, givenDirectory = process.cwd()) {
+  return globifyGitIgnoreEntry(posixifyPath(givenPath), givenDirectory)
+}
+
+/**
  * Globifies a directory
  * @param {string} givenDirectory The given directory to be globified
  */

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -14,6 +14,11 @@ export function posixifyPath(givenPath) {
 export function posixifyPathNormalized(givenPath) {
   return posixifyPath(givenPath).replace(/[/\\]$/, "")
 }
+
+function isWhitespace(str) {
+  return /^\s*$/.test(str)
+}
+
 /**
  * A line starting with # serves as a comment.
  * Put a backslash ("\") in front of the first hash for patterns that begin with a hash.

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -111,8 +111,8 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
 
   // Process slash
 
-  /** @param {0 | 1 | 2} 1 for directory, 2 for file, 0 for others */
-  let pathType = 0
+  /** @type {PATH_TYPE.OTHER | PATH_TYPE.DIRECTORY | PATH_TYPE.FILE} */
+  let pathType = PATH_TYPE.OTHER
 
   if (entry[0] === "/") {
     // Patterns starting with '/' in gitignore are considred relative to the project directory while glob
@@ -133,7 +133,7 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
     } else if (slashPlacement === entry.length - 1) {
       // If there is a separator at the end of the pattern then it only matches directories
       // slash is in the end
-      pathType = 1
+      pathType = PATH_TYPE.DIRECTORY
     } else {
       // has `/` in the middle so it is a relative path
       // Check if it is a directory or file
@@ -152,14 +152,15 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
   entry = forceInclude ? entry : `!${entry}`
 
   // Process the entry ending
-  if (/** is directory */ pathType === 1) {
+  if (pathType === PATH_TYPE.DIRECTORY) {
     // in glob this is equal to `directry/**`
     if (entry.endsWith("/")) {
       return `${entry}**`
     } else {
       return `${entry}/**`
     }
-  } else if (/** is file */ pathType === 2) {
+  } else if (pathType === PATH_TYPE.FILE) {
+    // return as is for file
     return entry
   } else if (!entry.endsWith("/**")) {
     // the pattern can match both files and directories
@@ -205,21 +206,28 @@ function trimWhiteSpace(str) {
   return trimLeadingWhiteSpace(trimTrailingWhitespace(str))
 }
 
-/** Get the type of the given path (1 for directory, 2 for file, 0 for others)
+/** Enum that specifies the path type. 1 for directory, 2 for file, 0 for others */
+const PATH_TYPE = {
+  OTHER: 0,
+  DIRECTORY: 1,
+  FILE: 2,
+}
+
+/** Get the type of the given path
  * @param {string} givenPath absolute path
- * @returns {Promise<number>}
+ * @returns {Promise<PATH_TYPE.OTHER | PATH_TYPE.DIRECTORY | PATH_TYPE.FILE>}
  */
 async function getPathType(filepath) {
   let pathStat
   try {
     pathStat = await stat(filepath)
   } catch (error) {
-    return 0
+    return PATH_TYPE.OTHER
   }
   if (pathStat.isDirectory()) {
-    return 1
+    return PATH_TYPE.DIRECTORY
   } else if (pathStat.isFile()) {
-    return 2
+    return PATH_TYPE.FILE
   }
-  return 0
+  return PATH_TYPE.OTHER
 }

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -6,3 +6,11 @@ import path from "path"
 export function posixifyPath(givenPath) {
   return path.normalize(givenPath).replace(/\\/g, "/")
 }
+
+/** Converts given path to Posix (replacing \\ with /) and removing ending slashes
+ * @param {string} givenPath   Path to convert
+ * @returns {string}          Converted filepath
+ */
+export function posixifyPathNormalized(givenPath) {
+  return posixifyPath(givenPath).replace(/[/\\]$/, "")
+}

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -1,6 +1,8 @@
 import path from "path"
 import { promises } from "fs"
-const { readFile } = promises
+const { readFile, stat } = promises
+
+import isPath from "is-valid-path"
 
 import { unique } from "./utils"
 
@@ -23,10 +25,10 @@ export function posixifyPathNormalized(givenPath) {
 /**
  * @param {string} givenPath The given path to be globified
  * @param {string} givenDirectory [process.cwd()]  The cwd to use to resolve relative pathnames
- * @returns {string | [string, string]} The glob path or the file path itself
+ * @returns {Promise<string | [string, string]>} The glob path or the file path itself
  */
-export function globifyPath(givenPath, givenDirectory = process.cwd()) {
-  return globifyGitIgnoreEntry(posixifyPath(givenPath), givenDirectory)
+export async function globifyPath(givenPath, givenDirectory = process.cwd()) {
+  return await globifyGitIgnoreEntry(posixifyPath(givenPath), givenDirectory)
 }
 
 /**
@@ -43,16 +45,19 @@ export function globifyDirectory(givenDirectory) {
  * @returns {Promise<Array<string>>} an array of glob patterns
  */
 export async function globifyGitIgnoreFile(gitIgnoreDirectory) {
-  return globifyGitIgnore(await readFile(path.join(gitIgnoreDirectory, ".gitignore"), "utf-8"), gitIgnoreDirectory)
+  return await globifyGitIgnore(
+    await readFile(path.join(gitIgnoreDirectory, ".gitignore"), "utf-8"),
+    gitIgnoreDirectory
+  )
 }
 
 /**
  * Read `.gitingore` file from a directry
  * @param {string} gitIgnoreContent the content of the gitignore file
  * @param {string | undefined} gitIgnoreDirectory the directory of gitignore
- * @returns {Array<string>} an array of glob patterns
+ * @returns {Promise<Array<string>>} an array of glob patterns
  */
-export function globifyGitIgnore(gitIgnoreContent, gitIgnoreDirectory = undefined) {
+export async function globifyGitIgnore(gitIgnoreContent, gitIgnoreDirectory = undefined) {
   const gitIgnoreEntries = gitIgnoreContent
     .split("\n")
     // Remove empty lines and comments.
@@ -65,7 +70,7 @@ export function globifyGitIgnore(gitIgnoreContent, gitIgnoreDirectory = undefine
   let globEntries = new Array(gitIgnoreEntriesNum)
 
   for (let iEntry = 0; iEntry < gitIgnoreEntriesNum; iEntry++) {
-    const globifyOutput = globifyGitIgnoreEntry(gitIgnoreEntries[iEntry], gitIgnoreDirectory)
+    const globifyOutput = await globifyGitIgnoreEntry(gitIgnoreEntries[iEntry], gitIgnoreDirectory)
 
     // Check if `globifyGitIgnoreEntry` returns a pair or a string
     if (typeof globifyOutput === "string") {
@@ -85,9 +90,9 @@ export function globifyGitIgnore(gitIgnoreContent, gitIgnoreDirectory = undefine
 /**
  * @param {string} gitIgnoreEntry one git ignore entry (it expects a valid non-comment gitignore entry with no surrounding whitespace)
  * @param {string | undefined} gitIgnoreDirectory the directory of gitignore
- * @returns {string | [string, string]} the equivilant glob
+ * @returns {Promise<string | [string, string]>} the equivilant glob
  */
-function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
+async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
   // output glob entry
   let entry = gitIgnoreEntry
 
@@ -104,18 +109,33 @@ function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
   // If there is a separator at the beginning or middle (or both) of the pattern,
   // then the pattern is relative to the directory level of the particular .gitignore file itself
 
+  // Process slash
+  let definitelyDirectory = false
   if (entry[0] === "/") {
     // Patterns starting with '/' in gitignore are considred relative to the project directory while glob
     // treats them as relative to the OS root directory.
     // So we trim the slash to make it relative to project folder from glob perspective.
     entry = entry.substring(1)
+    // Check if it is a directory
+    if (await isPathAndDirectory(entry)) {
+      definitelyDirectory = true
+    }
   } else {
-    // Process the middle
-
-    if (entry.indexOf("/") === -1) {
+    const slashPlacement = entry.indexOf("/")
+    if (slashPlacement === -1) {
+      // Patterns that don't have `/` are '**/' from glob perspective (can match at any level)
       if (!entry.startsWith("**/")) {
-        // Patterns that don't have `/` are '**/' from glob perspective (can match at any level)
         entry = `**/${entry}`
+      }
+    } else if (slashPlacement === entry.length - 1) {
+      // If there is a separator at the end of the pattern then it only matches directories
+      // slash is in the end
+      definitelyDirectory = true
+    } else {
+      // has `/` in the middle so it is a relative path
+      // Check if it is a directory
+      if (await isPathAndDirectory(entry)) {
+        definitelyDirectory = true
       }
     }
   }
@@ -129,21 +149,20 @@ function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
   entry = forceInclude ? entry : `!${entry}`
 
   // Process the entry ending
-
-  if (entry.endsWith("/")) {
-    // If there is a separator at the end of the pattern then it only matches directories
+  if (definitelyDirectory) {
     // in glob this is equal to `directry/**`
-    entry = `${entry}**`
-  } else {
-    // unless already ends with /**
-    if (!entry.endsWith("/**")) {
-      // the pattern can match both files and directories
-      // so we should include both `entry` and `entry/**`
-      return [entry, `${entry}/**`]
+    if (entry.endsWith("/")) {
+      return `${entry}**`
+    } else {
+      return `${entry}/**`
     }
+  } else if (!entry.endsWith("/**")) {
+    // the pattern can match both files and directories
+    // so we should include both `entry` and `entry/**`
+    return [entry, `${entry}/**`]
+  } else {
+    return entry
   }
-
-  return entry
 }
 
 function isWhitespace(str) {
@@ -179,4 +198,20 @@ function trimLeadingWhiteSpace(str) {
 /** Remove whitespace from a gitignore entry */
 function trimWhiteSpace(str) {
   return trimLeadingWhiteSpace(trimTrailingWhitespace(str))
+}
+
+async function isPathAndDirectory(str) {
+  return (await isPath(str)) && (await isDirectory(str))
+}
+
+/** Check if the given path is a directory
+ * @param {string} givenPath absolute path
+ * @returns {Promise<boolean>}
+ */
+async function isDirectory(filepath) {
+  try {
+    return (await stat(filepath)).isDirectory()
+  } catch (error) {
+    return false
+  }
 }

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -14,3 +14,15 @@ export function posixifyPath(givenPath) {
 export function posixifyPathNormalized(givenPath) {
   return posixifyPath(givenPath).replace(/[/\\]$/, "")
 }
+/**
+ * Trailing spaces should be removed unless they are quoted with backslash ("\ ").
+ */
+function trimTrailingWhitespace(str) {
+  if (!/\\\s+$/.test(str)) {
+    // No escaped trailing whitespace, remove
+    return str.replace(/\s+$/, "")
+  } else {
+    // Trailing whitespace detected, remove only the backslash
+    return str.replace(/\\(\s+)$/, "$1")
+  }
+}

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -121,7 +121,7 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
     entry = entry.substring(1)
     // Check if it is a directory or file
     if (await isPath(entry)) {
-      pathType = await getPathType(entry)
+      pathType = await getPathType(gitIgnoreDirectory ? path.join(gitIgnoreDirectory, entry) : entry)
     }
   } else {
     const slashPlacement = entry.indexOf("/")
@@ -138,7 +138,7 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
       // has `/` in the middle so it is a relative path
       // Check if it is a directory or file
       if (await isPath(entry)) {
-        pathType = await getPathType(entry)
+        pathType = await getPathType(gitIgnoreDirectory ? path.join(gitIgnoreDirectory, entry) : entry)
       }
     }
   }

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -26,3 +26,9 @@ function trimTrailingWhitespace(str) {
     return str.replace(/\\(\s+)$/, "$1")
   }
 }
+
+/** Remove leading whitespace */
+function trimLeadingWhiteSpace(str) {
+  return str.replace(/^\s+/, "")
+}
+

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -32,3 +32,7 @@ function trimLeadingWhiteSpace(str) {
   return str.replace(/^\s+/, "")
 }
 
+/** Remove whitespace from a gitignore entry */
+function trimWhiteSpace(str) {
+  return trimLeadingWhiteSpace(trimTrailingWhitespace(str))
+}

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -19,7 +19,7 @@ export function posixifyPath(givenPath) {
  * @returns {string}          Converted filepath
  */
 export function posixifyPathNormalized(givenPath) {
-  return posixifyPath(givenPath).replace(/[/\\]$/, "")
+  return posixifyPath(givenPath).replace(/\/$/, "")
 }
 
 /**

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -21,6 +21,42 @@ export function posixifyPathNormalized(givenPath) {
 }
 
 /**
+ * Read `.gitingore` file from a directry
+ * @param {string} gitIgnoreContent the content of the gitignore file
+ * @param {string | undefined} gitIgnoreDirectory the directory of gitignore
+ * @returns {Array<string>} an array of glob patterns
+ */
+export function globifyGitIgnore(gitIgnoreContent, gitIgnoreDirectory = undefined) {
+  const gitIgnoreEntries = gitIgnoreContent
+    .split("\n")
+    // Remove empty lines and comments.
+    .filter((entry) => !(isWhitespace(entry) || isGitIgnoreComment(entry, "#")))
+    // Remove surrounding whitespace
+    .map((entry) => trimWhiteSpace(entry))
+
+  const gitIgnoreEntriesNum = gitIgnoreEntries.length
+
+  let globEntries = new Array(gitIgnoreEntriesNum)
+
+  for (let iEntry = 0; iEntry < gitIgnoreEntriesNum; iEntry++) {
+    const globifyOutput = globifyGitIgnoreEntry(gitIgnoreEntries[iEntry], gitIgnoreDirectory)
+
+    // Check if `globifyGitIgnoreEntry` returns a pair or a string
+    if (typeof globifyOutput === "string") {
+      // string
+      globEntries[iEntry] = globifyOutput // Place the entry in the output array
+    } else {
+      // pair
+      globEntries[iEntry] = globifyOutput[0] // Place the entry in the output array
+      globEntries.push(globifyOutput[1]) // Push the additional entry
+    }
+  }
+
+  // unique in the end
+  return unique(globEntries)
+}
+
+/**
  * @param {string} gitIgnoreEntry one git ignore entry (it expects a valid non-comment gitignore entry with no surrounding whitespace)
  * @param {string | undefined} gitIgnoreDirectory the directory of gitignore
  * @returns {string | [string, string]} the equivilant glob

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -21,6 +21,14 @@ export function posixifyPathNormalized(givenPath) {
 }
 
 /**
+ * Globifies a directory
+ * @param {string} givenDirectory The given directory to be globified
+ */
+export function globifyDirectory(givenDirectory) {
+  return `${posixifyPathNormalized(givenDirectory)}/**`
+}
+
+/**
  * Parse and globy the `.gitingore` file that exists in a directry
  * @param {string} gitIgnoreDirectory The given directory that has the `.gitignore` file
  * @returns {Promise<Array<string>>} an array of glob patterns

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -110,15 +110,18 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
   // then the pattern is relative to the directory level of the particular .gitignore file itself
 
   // Process slash
-  let definitelyDirectory = false
+
+  /** @param {0 | 1 | 2} 1 for directory, 2 for file, 0 for others */
+  let pathType = 0
+
   if (entry[0] === "/") {
     // Patterns starting with '/' in gitignore are considred relative to the project directory while glob
     // treats them as relative to the OS root directory.
     // So we trim the slash to make it relative to project folder from glob perspective.
     entry = entry.substring(1)
-    // Check if it is a directory
-    if (await isPathAndDirectory(entry)) {
-      definitelyDirectory = true
+    // Check if it is a directory or file
+    if (await isPath(entry)) {
+      pathType = await getPathType(entry)
     }
   } else {
     const slashPlacement = entry.indexOf("/")
@@ -130,12 +133,12 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
     } else if (slashPlacement === entry.length - 1) {
       // If there is a separator at the end of the pattern then it only matches directories
       // slash is in the end
-      definitelyDirectory = true
+      pathType = 1
     } else {
       // has `/` in the middle so it is a relative path
-      // Check if it is a directory
-      if (await isPathAndDirectory(entry)) {
-        definitelyDirectory = true
+      // Check if it is a directory or file
+      if (await isPath(entry)) {
+        pathType = await getPathType(entry)
       }
     }
   }
@@ -149,13 +152,15 @@ async function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
   entry = forceInclude ? entry : `!${entry}`
 
   // Process the entry ending
-  if (definitelyDirectory) {
+  if (/** is directory */ pathType === 1) {
     // in glob this is equal to `directry/**`
     if (entry.endsWith("/")) {
       return `${entry}**`
     } else {
       return `${entry}/**`
     }
+  } else if (/** is file */ pathType === 2) {
+    return entry
   } else if (!entry.endsWith("/**")) {
     // the pattern can match both files and directories
     // so we should include both `entry` and `entry/**`
@@ -200,18 +205,21 @@ function trimWhiteSpace(str) {
   return trimLeadingWhiteSpace(trimTrailingWhitespace(str))
 }
 
-async function isPathAndDirectory(str) {
-  return (await isPath(str)) && (await isDirectory(str))
-}
-
-/** Check if the given path is a directory
+/** Get the type of the given path (1 for directory, 2 for file, 0 for others)
  * @param {string} givenPath absolute path
- * @returns {Promise<boolean>}
+ * @returns {Promise<number>}
  */
-async function isDirectory(filepath) {
+async function getPathType(filepath) {
+  let pathStat
   try {
-    return (await stat(filepath)).isDirectory()
+    pathStat = await stat(filepath)
   } catch (error) {
-    return false
+    return 0
   }
+  if (pathStat.isDirectory()) {
+    return 1
+  } else if (pathStat.isFile()) {
+    return 2
+  }
+  return 0
 }

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -1,4 +1,9 @@
 import path from "path"
+import { promises } from "fs"
+const { readFile } = promises
+
+import { unique } from "./utils"
+
 /** Converts given path to Posix (replacing \\ with /)
  * @param {string} givenPath   Path to convert
  * @returns {string}          Converted filepath
@@ -13,6 +18,70 @@ export function posixifyPath(givenPath) {
  */
 export function posixifyPathNormalized(givenPath) {
   return posixifyPath(givenPath).replace(/[/\\]$/, "")
+}
+
+/**
+ * @param {string} gitIgnoreEntry one git ignore entry (it expects a valid non-comment gitignore entry with no surrounding whitespace)
+ * @param {string | undefined} gitIgnoreDirectory the directory of gitignore
+ * @returns {string | [string, string]} the equivilant glob
+ */
+function globifyGitIgnoreEntry(gitIgnoreEntry, gitIgnoreDirectory) {
+  // output glob entry
+  let entry = gitIgnoreEntry
+
+  // Process the entry beginning
+
+  // '!' in .gitignore means to force include the pattern
+  // remove "!" to allow the processing of the pattern and swap ! in the end of the loop
+  let forceInclude = false
+  if (entry[0] === "!") {
+    entry = entry.substring(1)
+    forceInclude = true
+  }
+
+  // If there is a separator at the beginning or middle (or both) of the pattern,
+  // then the pattern is relative to the directory level of the particular .gitignore file itself
+
+  if (entry[0] === "/") {
+    // Patterns starting with '/' in gitignore are considred relative to the project directory while glob
+    // treats them as relative to the OS root directory.
+    // So we trim the slash to make it relative to project folder from glob perspective.
+    entry = entry.substring(1)
+  } else {
+    // Process the middle
+
+    if (entry.indexOf("/") === -1) {
+      if (!entry.startsWith("**/")) {
+        // Patterns that don't have `/` are '**/' from glob perspective (can match at any level)
+        entry = `**/${entry}`
+      }
+    }
+  }
+
+  // prepend the absolute root directory
+  if (gitIgnoreDirectory) {
+    entry = `${posixifyPath(gitIgnoreDirectory)}/${entry}`
+  }
+
+  // swap !
+  entry = forceInclude ? entry : `!${entry}`
+
+  // Process the entry ending
+
+  if (entry.endsWith("/")) {
+    // If there is a separator at the end of the pattern then it only matches directories
+    // in glob this is equal to `directry/**`
+    entry = `${entry}**`
+  } else {
+    // unless already ends with /**
+    if (!entry.endsWith("/**")) {
+      // the pattern can match both files and directories
+      // so we should include both `entry` and `entry/**`
+      return [entry, `${entry}/**`]
+    }
+  }
+
+  return entry
 }
 
 function isWhitespace(str) {

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -21,6 +21,15 @@ export function posixifyPathNormalized(givenPath) {
 }
 
 /**
+ * Parse and globy the `.gitingore` file that exists in a directry
+ * @param {string} gitIgnoreDirectory The given directory that has the `.gitignore` file
+ * @returns {Promise<Array<string>>} an array of glob patterns
+ */
+export async function globifyGitIgnoreFile(gitIgnoreDirectory) {
+  return globifyGitIgnore(await readFile(path.join(gitIgnoreDirectory, ".gitignore"), "utf-8"), gitIgnoreDirectory)
+}
+
+/**
  * Read `.gitingore` file from a directry
  * @param {string} gitIgnoreContent the content of the gitignore file
  * @param {string | undefined} gitIgnoreDirectory the directory of gitignore

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -352,10 +352,10 @@ export default class PathsCache extends EventEmitter {
   /**
    * Returns a list of ignore patterns for a directory
    * @param  {String} directoryPath
-   * @returns {Array<string>} an array of glob patterns
+   * @returns {Promise<Array<string>>} an array of glob patterns
    * @private
    */
-  _getIgnoredPatternsGlob(directoryPath) {
+  async _getIgnoredPatternsGlob(directoryPath) {
     const patterns = []
 
     if (this.config.shouldIgnoredNames) {
@@ -371,7 +371,7 @@ export default class PathsCache extends EventEmitter {
     let globEntries = new Array(patternsNum)
 
     for (let iEntry = 0; iEntry < patternsNum; iEntry++) {
-      const globifyOutput = globifyPath(patterns[iEntry], directoryPath)
+      const globifyOutput = await globifyPath(patterns[iEntry], directoryPath)
 
       // Check if `globifyPath` returns a pair or a string
       if (typeof globifyOutput === "string") {
@@ -412,7 +412,7 @@ export default class PathsCache extends EventEmitter {
   async _populateCacheWithGlob(directoryPath) {
     const directoryGlob = globifyDirectory(directoryPath)
     const gitignoreGlob = await this._getGitIgnoreGlob(directoryPath)
-    const ignoredPatternsGlob = this._getIgnoredPatternsGlob(directoryPath)
+    const ignoredPatternsGlob = await this._getIgnoredPatternsGlob(directoryPath)
 
     const files = await glob(
       [directoryGlob, ...gitignoreGlob, ...ignoredPatternsGlob],

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -97,7 +97,7 @@ export default class PathsCache extends EventEmitter {
   _onDirectoryChanged(projectDirectory, directory) {
     this._removeFilePathsForDirectory(projectDirectory, directory)
     this._cleanWatchersForDirectory(directory)
-    this._populateCacheFor(directory.path).catch((e) => {
+    this._populateCacheWithGlob(directory.path).catch((e) => {
       // fallback to Atom
       console.error(e)
       this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory)
@@ -289,7 +289,7 @@ export default class PathsCache extends EventEmitter {
   async _buildInitialCacheWithGlob() {
     await this._cacheProjectPathsAndRepositories()
     const result = await Promise.all(
-      this._projectDirectories.map((projectDirectory) => this._populateCacheFor(projectDirectory.path))
+      this._projectDirectories.map((projectDirectory) => this._populateCacheWithGlob(projectDirectory.path))
     )
 
     this.emit("rebuild-cache-done")
@@ -409,7 +409,7 @@ export default class PathsCache extends EventEmitter {
    * @return {Promise<Array<string>>}
    * @private
    */
-  async _populateCacheFor(directoryPath) {
+  async _populateCacheWithGlob(directoryPath) {
     const directoryGlob = globifyDirectory(directoryPath)
     const gitignoreGlob = await this._getGitIgnoreGlob(directoryPath)
     const ignoredPatternsGlob = this._getIgnoredPatternsGlob(directoryPath)

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -36,6 +36,58 @@ export default class PathsCache extends EventEmitter {
   }
 
   /**
+   * Rebuilds the paths cache
+   */
+  async rebuildCache() {
+    this.dispose()
+
+    this._cancelled = false
+    this.emit("rebuild-cache")
+
+    try {
+      return await this._buildInitialCacheWithGlob()
+    } catch (e) {
+      console.error(e)
+      return await this._buildInitialCacheWithAtom()
+    }
+  }
+
+  /**
+   * Returns the file paths for the given project directory with the given (optional) relative path
+   * @param  {Directory} projectDirectory
+   * @param  {String} [relativeToPath=null]
+   * @return {String[]}
+   */
+  getFilePathsForProjectDirectory(projectDirectory, relativeToPath = null) {
+    let filePaths = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
+    if (relativeToPath) {
+      return filePaths.filter((filePath) => filePath.indexOf(relativeToPath) === 0)
+    }
+    return filePaths
+  }
+
+  /**
+   * Disposes this PathsCache
+   */
+  dispose(isPackageDispose) {
+    this._fileWatchersByDirectory.forEach((watcher) => {
+      watcher.dispose()
+    })
+    this._fileWatchersByDirectory = new Map()
+    this._filePathsByProjectDirectory = new Map()
+    this._filePathsByDirectory = new Map()
+    this._repositories = []
+    if (this._projectWatcher) {
+      this._projectWatcher.dispose()
+      this._projectWatcher = null
+    }
+    if (isPackageDispose && this._projectChangeWatcher) {
+      this._projectChangeWatcher.dispose()
+      this._projectChangeWatcher = null
+    }
+  }
+
+  /**
    * Checks if the given path is ignored
    * @param  {String}  path
    * @return {Boolean}
@@ -100,7 +152,7 @@ export default class PathsCache extends EventEmitter {
     this._populateCacheWithGlob(directory.path).catch((e) => {
       // fallback to Atom
       console.error(e)
-      this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory)
+      this._populateCacheWithAtom(projectDirectory, directory)
     })
   }
 
@@ -135,66 +187,6 @@ export default class PathsCache extends EventEmitter {
   }
 
   /**
-   * Caches file paths for the given directory
-   * @param  {Directory} projectDirectory
-   * @param  {Directory} directory
-   * @return {Promise}
-   * @private
-   */
-  async _cacheDirectoryFilePathsWithAtom(projectDirectory, directory) {
-    if (this._cancelled) return []
-
-    if (process.platform !== "win32") {
-      let watcher = this._fileWatchersByDirectory.get(directory)
-      if (!watcher) {
-        watcher = directory.onDidChange(() => this._onDirectoryChanged(projectDirectory, directory))
-        this._fileWatchersByDirectory.set(directory, watcher)
-      }
-    }
-    const entries = await this._getDirectoryEntries(directory)
-    if (this._cancelled) return []
-
-    // Filter: Files and Directories that are not ignored
-    let filePaths = []
-    let directories = []
-    for (let i = 0, len = entries.length; i < len; i++) {
-      const entry = entries[i]
-      if (entry instanceof File && !this._isPathIgnored(entry.path)) {
-        filePaths.push(entry.path)
-      } else if (entry instanceof Directory && !this._isPathIgnored(entry.path)) {
-        directories.push(entry)
-      }
-    }
-
-    // Merge file paths into existing array (which contains *all* file paths)
-    let filePathsArray = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
-    const newPathsCount = filePathsArray.length + filePaths.length
-
-    if (newPathsCount > this.config.maxFileCount && !this._cancelled) {
-      atom.notifications.addError("autocomplete-paths", {
-        description: `Maximum file count of ${this.config.maxFileCount} has been exceeded. Path autocompletion will not work in this project.<br /><br /><a href="https://github.com/atom-community/autocomplete-paths/wiki/Troubleshooting#maximum-file-limit-exceeded">Click here to learn more.</a>`,
-        dismissable: true,
-      })
-
-      this._filePathsByProjectDirectory.clear()
-      this._filePathsByDirectory.clear()
-      this._cancelled = true
-      this.emit("rebuild-cache-done")
-      return
-    }
-
-    this._filePathsByProjectDirectory.set(projectDirectory.path, union(filePathsArray, filePaths))
-
-    // Merge file paths into existing array (which contains file paths for a specific directory)
-    filePathsArray = this._filePathsByDirectory.get(directory.path) || []
-    this._filePathsByDirectory.set(directory.path, union(filePathsArray, filePaths))
-
-    return Promise.all(
-      directories.map((directory) => this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory))
-    )
-  }
-
-  /**
    * Promisified version of Directory#getEntries
    * @param  {Directory} directory
    * @return {Promise}
@@ -207,93 +199,6 @@ export default class PathsCache extends EventEmitter {
         resolve(entries)
       })
     })
-  }
-
-  /**
-   * Rebuilds the paths cache
-   */
-  async rebuildCache() {
-    this.dispose()
-
-    this._cancelled = false
-    this.emit("rebuild-cache")
-
-    try {
-      return await this._buildInitialCacheWithGlob()
-    } catch (e) {
-      console.error(e)
-      return await this._buildInitialCacheWithAtom()
-    }
-  }
-
-  /**
-   * Builds the initial file cache using Atom
-   * @return {Promise}
-   * @private
-   */
-  async _buildInitialCacheWithAtom() {
-    await this._cacheProjectPathsAndRepositories()
-    const result = await Promise.all(
-      this._projectDirectories.map((projectDirectory) => {
-        return this._cacheDirectoryFilePathsWithAtom(projectDirectory, projectDirectory)
-      })
-    )
-    this.emit("rebuild-cache-done")
-    return result
-  }
-
-  /**
-   * Returns the file paths for the given project directory with the given (optional) relative path
-   * @param  {Directory} projectDirectory
-   * @param  {String} [relativeToPath=null]
-   * @return {String[]}
-   */
-  getFilePathsForProjectDirectory(projectDirectory, relativeToPath = null) {
-    let filePaths = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
-    if (relativeToPath) {
-      return filePaths.filter((filePath) => filePath.indexOf(relativeToPath) === 0)
-    }
-    return filePaths
-  }
-
-  /**
-   * Disposes this PathsCache
-   */
-  dispose(isPackageDispose) {
-    this._fileWatchersByDirectory.forEach((watcher) => {
-      watcher.dispose()
-    })
-    this._fileWatchersByDirectory = new Map()
-    this._filePathsByProjectDirectory = new Map()
-    this._filePathsByDirectory = new Map()
-    this._repositories = []
-    if (this._projectWatcher) {
-      this._projectWatcher.dispose()
-      this._projectWatcher = null
-    }
-    if (isPackageDispose && this._projectChangeWatcher) {
-      this._projectChangeWatcher.dispose()
-      this._projectChangeWatcher = null
-    }
-  }
-
-  //
-  // Cache with `find`
-  //
-
-  /**
-   * Builds the initial file cache with `find`
-   * @return {Promise}
-   * @private
-   */
-  async _buildInitialCacheWithGlob() {
-    await this._cacheProjectPathsAndRepositories()
-    const result = await Promise.all(
-      this._projectDirectories.map((projectDirectory) => this._populateCacheWithGlob(projectDirectory.path))
-    )
-
-    this.emit("rebuild-cache-done")
-    return result
   }
 
   _onDidChangeFiles(events) {
@@ -347,6 +252,29 @@ export default class PathsCache extends EventEmitter {
           this._filePathsByProjectDirectory.set(directoryPath, files)
         }
       })
+  }
+
+  /*
+   ██████  ██       ██████  ██████
+  ██       ██      ██    ██ ██   ██
+  ██   ███ ██      ██    ██ ██████
+  ██    ██ ██      ██    ██ ██   ██
+   ██████  ███████  ██████  ██████
+  */
+
+  /**
+   * Builds the initial file cache with `glob`
+   * @return {Promise}
+   * @private
+   */
+  async _buildInitialCacheWithGlob() {
+    await this._cacheProjectPathsAndRepositories()
+    const result = await Promise.all(
+      this._projectDirectories.map((projectDirectory) => this._populateCacheWithGlob(projectDirectory.path))
+    )
+
+    this.emit("rebuild-cache-done")
+    return result
   }
 
   /**
@@ -425,5 +353,87 @@ export default class PathsCache extends EventEmitter {
     )
     this._filePathsByProjectDirectory.set(directoryPath, files)
     return files
+  }
+
+  /*
+  ███████  █████  ██      ██      ██████   █████   ██████ ██   ██
+  ██      ██   ██ ██      ██      ██   ██ ██   ██ ██      ██  ██
+  █████   ███████ ██      ██      ██████  ███████ ██      █████
+  ██      ██   ██ ██      ██      ██   ██ ██   ██ ██      ██  ██
+  ██      ██   ██ ███████ ███████ ██████  ██   ██  ██████ ██   ██
+  */
+
+  /**
+   * Builds the initial file cache using Atom
+   * @return {Promise}
+   * @private
+   */
+  async _buildInitialCacheWithAtom() {
+    await this._cacheProjectPathsAndRepositories()
+    const result = await Promise.all(
+      this._projectDirectories.map((projectDirectory) => {
+        return this._populateCacheWithAtom(projectDirectory, projectDirectory)
+      })
+    )
+    this.emit("rebuild-cache-done")
+    return result
+  }
+
+  /**
+   * Caches file paths for the given directory with Atom
+   * @param  {Directory} projectDirectory
+   * @param  {Directory} directory
+   * @return {Promise}
+   * @private
+   */
+  async _populateCacheWithAtom(projectDirectory, directory) {
+    if (this._cancelled) return []
+
+    if (process.platform !== "win32") {
+      let watcher = this._fileWatchersByDirectory.get(directory)
+      if (!watcher) {
+        watcher = directory.onDidChange(() => this._onDirectoryChanged(projectDirectory, directory))
+        this._fileWatchersByDirectory.set(directory, watcher)
+      }
+    }
+    const entries = await this._getDirectoryEntries(directory)
+    if (this._cancelled) return []
+
+    // Filter: Files and Directories that are not ignored
+    let filePaths = []
+    let directories = []
+    for (let i = 0, len = entries.length; i < len; i++) {
+      const entry = entries[i]
+      if (entry instanceof File && !this._isPathIgnored(entry.path)) {
+        filePaths.push(entry.path)
+      } else if (entry instanceof Directory && !this._isPathIgnored(entry.path)) {
+        directories.push(entry)
+      }
+    }
+
+    // Merge file paths into existing array (which contains *all* file paths)
+    let filePathsArray = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
+    const newPathsCount = filePathsArray.length + filePaths.length
+
+    if (newPathsCount > this.config.maxFileCount && !this._cancelled) {
+      atom.notifications.addError("autocomplete-paths", {
+        description: `Maximum file count of ${this.config.maxFileCount} has been exceeded. Path autocompletion will not work in this project.<br /><br /><a href="https://github.com/atom-community/autocomplete-paths/wiki/Troubleshooting#maximum-file-limit-exceeded">Click here to learn more.</a>`,
+        dismissable: true,
+      })
+
+      this._filePathsByProjectDirectory.clear()
+      this._filePathsByDirectory.clear()
+      this._cancelled = true
+      this.emit("rebuild-cache-done")
+      return
+    }
+
+    this._filePathsByProjectDirectory.set(projectDirectory.path, union(filePathsArray, filePaths))
+
+    // Merge file paths into existing array (which contains file paths for a specific directory)
+    filePathsArray = this._filePathsByDirectory.get(directory.path) || []
+    this._filePathsByDirectory.set(directory.path, union(filePathsArray, filePaths))
+
+    return Promise.all(directories.map((directory) => this._populateCacheWithAtom(projectDirectory, directory)))
   }
 }

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -97,7 +97,7 @@ export default class PathsCache extends EventEmitter {
   _onDirectoryChanged(projectDirectory, directory) {
     this._removeFilePathsForDirectory(projectDirectory, directory)
     this._cleanWatchersForDirectory(directory)
-    this._cacheDirectoryFilePaths(projectDirectory, directory)
+    this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory)
   }
 
   /**
@@ -137,7 +137,7 @@ export default class PathsCache extends EventEmitter {
    * @return {Promise}
    * @private
    */
-  async _cacheDirectoryFilePaths(projectDirectory, directory) {
+  async _cacheDirectoryFilePathsWithAtom(projectDirectory, directory) {
     if (this._cancelled) return []
 
     if (process.platform !== "win32") {
@@ -185,7 +185,9 @@ export default class PathsCache extends EventEmitter {
     filePathsArray = this._filePathsByDirectory.get(directory.path) || []
     this._filePathsByDirectory.set(directory.path, union(filePathsArray, filePaths))
 
-    return Promise.all(directories.map((directory) => this._cacheDirectoryFilePaths(projectDirectory, directory)))
+    return Promise.all(
+      directories.map((directory) => this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory))
+    )
   }
 
   /**
@@ -229,7 +231,7 @@ export default class PathsCache extends EventEmitter {
     await this._cacheProjectPathsAndRepositories()
     const result = await Promise.all(
       this._projectDirectories.map((projectDirectory) => {
-        return this._cacheDirectoryFilePaths(projectDirectory, projectDirectory)
+        return this._cacheDirectoryFilePathsWithAtom(projectDirectory, projectDirectory)
       })
     )
     this.emit("rebuild-cache-done")

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -206,16 +206,18 @@ export default class PathsCache extends EventEmitter {
   /**
    * Rebuilds the paths cache
    */
-  rebuildCache() {
+  async rebuildCache() {
     this.dispose()
 
     this._cancelled = false
     this.emit("rebuild-cache")
 
-    return this._buildInitialCacheWithGlob().catch((e) => {
+    try {
+      return await this._buildInitialCacheWithGlob()
+    } catch (e) {
       console.error(e)
-      return this._buildInitialCacheWithAtom()
-    })
+      return await this._buildInitialCacheWithAtom()
+    }
   }
 
   /**

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -379,20 +379,22 @@ export default class PathsCache extends EventEmitter {
     }
     return globEntries
   }
+
+  /**
+   * Returns the glob pattern of a gitignore of a directory
+   * @param  {String} directoryPath
+   * @returns {Promise<Array<string>>} an array of glob patterns
+   * @private
+   */
+  async _getGitIgnoreGlob(directoryPath) {
     if (this.config.excludeVcsIgnoredPaths) {
       try {
-        const gitIgnore = fs.readFileSync(directoryPath + "/.gitignore", "utf-8")
-        gitIgnoreParser(gitIgnore).forEach((pattern) => patterns.push(pattern))
+        return await globifyGitIgnoreFile(directoryPath)
       } catch (err) {
         // .gitignore does not exist for this directory, ignoring
       }
     }
-
-    if (this.config.ignoredPatterns) {
-      this.config.ignoredPatterns.forEach((pattern) => patterns.push(pattern))
-    }
-
-    return patterns
+    return []
   }
 
   /**

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -282,7 +282,9 @@ export default class PathsCache extends EventEmitter {
    */
   async _buildInitialCacheWithGlob() {
     await this._cacheProjectPathsAndRepositories()
-    const result = await Promise.all(this._projectDirectories.map((d) => this._populateCacheFor(d)))
+    const result = await Promise.all(
+      this._projectDirectories.map((projectDirectory) => this._populateCacheFor(projectDirectory.path))
+    )
 
     this.emit("rebuild-cache-done")
     return result
@@ -396,14 +398,12 @@ export default class PathsCache extends EventEmitter {
   }
 
   /**
-   * Populates cache for a project directory
-   * @param  {Directory} projectDirectory
-   * @return {Promise}
+   * Populates cache for the given directory
+   * @param  {string} directoryPath the given directory path
+   * @return {Promise<Array<string>>}
    * @private
    */
-  async _populateCacheFor(projectDirectory) {
-    const directoryPath = projectDirectory.path
-
+  async _populateCacheFor(directoryPath) {
     const directoryGlob = globifyDirectory(directoryPath)
     const gitignoreGlob = await this._getGitIgnoreGlob(directoryPath)
     const ignoredPatternsGlob = this._getIgnoredPatternsGlob(directoryPath)

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -1,12 +1,10 @@
 "use babel"
-
 import { EventEmitter } from "events"
-import fs from "fs"
-import gitIgnoreParser from "git-ignore-parser"
-import { compact } from "underscore"
 import minimatch from "minimatch"
 import { Directory, File } from "atom"
-import { union, exec, MAX_STRING_LENGTH } from "./utils"
+import { union } from "./utils"
+import { globifyPath, globifyDirectory, globifyGitIgnoreFile } from "./path-utils"
+import glob from "fast-glob"
 
 export default class PathsCache extends EventEmitter {
   constructor() {
@@ -214,20 +212,18 @@ export default class PathsCache extends EventEmitter {
     this._cancelled = false
     this.emit("rebuild-cache")
 
-    return exec("find", ["--version"], { maxBuffer: MAX_STRING_LENGTH }).then(
-      // `find` is available
-      () => this._buildInitialCacheWithFind(),
-      // `find` is not available
-      () => this._buildInitialCache()
-    )
+    return this._buildInitialCacheWithGlob().catch((e) => {
+      console.error(e)
+      return this._buildInitialCacheWithAtom()
+    })
   }
 
   /**
-   * Builds the initial file cache
+   * Builds the initial file cache using Atom
    * @return {Promise}
    * @private
    */
-  async _buildInitialCache() {
+  async _buildInitialCacheWithAtom() {
     await this._cacheProjectPathsAndRepositories()
     const result = await Promise.all(
       this._projectDirectories.map((projectDirectory) => {
@@ -282,9 +278,9 @@ export default class PathsCache extends EventEmitter {
    * @return {Promise}
    * @private
    */
-  async _buildInitialCacheWithFind() {
+  async _buildInitialCacheWithGlob() {
     await this._cacheProjectPathsAndRepositories()
-    const result = await Promise.all(this._projectDirectories.map(this._populateCacheFor.bind(this)))
+    const result = await Promise.all(this._projectDirectories.map((d) => this._populateCacheFor(d)))
 
     this.emit("rebuild-cache-done")
     return result
@@ -406,18 +402,20 @@ export default class PathsCache extends EventEmitter {
   async _populateCacheFor(projectDirectory) {
     const directoryPath = projectDirectory.path
 
-    const ignorePatterns = this._getIgnorePatterns(directoryPath)
-    const ignorePatternsForFind = ignorePatterns.map((pattern) => pattern.replace(/\./g, "\\.").replace(/\*/g, ".*"))
-    const ignorePattern = "'.*\\(" + ignorePatternsForFind.join("\\|") + "\\).*'"
+    const directoryGlob = globifyDirectory(directoryPath)
+    const gitignoreGlob = await this._getGitIgnoreGlob(directoryPath)
+    const ignoredPatternsGlob = this._getIgnoredPatternsGlob(directoryPath)
 
-    const cmd = "find"
-    const args = ["-L", directoryPath + "/", "-type", "f", "-not", "-regex", ignorePattern]
-
-    const stdout = await exec(cmd, args)
-    const files = compact(stdout.toString().split("\n"))
-
+    const files = await glob(
+      [directoryGlob, ...gitignoreGlob, ...ignoredPatternsGlob],
+      // glob options
+      {
+        dot: true,
+        cwd: directoryPath,
+        onlyFiles: true,
+      }
+    )
     this._filePathsByProjectDirectory.set(directoryPath, files)
-
     return files
   }
 }

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -346,16 +346,39 @@ export default class PathsCache extends EventEmitter {
   /**
    * Returns a list of ignore patterns for a directory
    * @param  {String} directoryPath
-   * @return {String[]}
+   * @returns {Array<string>} an array of glob patterns
    * @private
    */
-  _getIgnorePatterns(directoryPath) {
+  _getIgnoredPatternsGlob(directoryPath) {
     const patterns = []
 
     if (this.config.shouldIgnoredNames) {
-      this.config.ignoredNames.forEach((pattern) => patterns.push(pattern))
+      patterns.push(...this.config.ignoredNames)
     }
 
+    if (this.config.ignoredPatterns) {
+      patterns.push(...this.config.ignoredPatterns)
+    }
+
+    const patternsNum = patterns.length
+
+    let globEntries = new Array(patternsNum)
+
+    for (let iEntry = 0; iEntry < patternsNum; iEntry++) {
+      const globifyOutput = globifyPath(patterns[iEntry], directoryPath)
+
+      // Check if `globifyGitIgnoreEntry` returns a pair or a string
+      if (typeof globifyOutput === "string") {
+        // string
+        globEntries[iEntry] = globifyOutput // Place the entry in the output array
+      } else {
+        // pair
+        globEntries[iEntry] = globifyOutput[0] // Place the entry in the output array
+        globEntries.push(globifyOutput[1]) // Push the additional entry
+      }
+    }
+    return globEntries
+  }
     if (this.config.excludeVcsIgnoredPaths) {
       try {
         const gitIgnore = fs.readFileSync(directoryPath + "/.gitignore", "utf-8")

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -97,7 +97,11 @@ export default class PathsCache extends EventEmitter {
   _onDirectoryChanged(projectDirectory, directory) {
     this._removeFilePathsForDirectory(projectDirectory, directory)
     this._cleanWatchersForDirectory(directory)
-    this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory)
+    this._populateCacheFor(directory.path).catch((e) => {
+      // fallback to Atom
+      console.error(e)
+      this._cacheDirectoryFilePathsWithAtom(projectDirectory, directory)
+    })
   }
 
   /**

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -363,7 +363,7 @@ export default class PathsCache extends EventEmitter {
     for (let iEntry = 0; iEntry < patternsNum; iEntry++) {
       const globifyOutput = globifyPath(patterns[iEntry], directoryPath)
 
-      // Check if `globifyGitIgnoreEntry` returns a pair or a string
+      // Check if `globifyPath` returns a pair or a string
       if (typeof globifyOutput === "string") {
         // string
         globEntries[iEntry] = globifyOutput // Place the entry in the output array

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.5",
+    "is-glob": "^4.0.1",
+    "is-valid-path": "^0.1.1",
     "minimatch": "^3.0.4",
     "slash": "^3.0.0",
     "underscore": "^1.12.0",
@@ -43,6 +45,7 @@
   "devDependencies": {
     "@babel/cli": "^7.13.0",
     "@babel/core": "^7.13.8",
+    "@types/is-valid-path": "^0.1.0",
     "@types/minimatch": "^3.0.3",
     "@types/node": "^14.14.31",
     "@types/underscore": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
     "lint": "eslint . --fix",
     "test.lint": "eslint .",
     "clean": "shx rm -rf dist .parcel-cache",
-    "build.worker": "cross-env NODE_ENV=production parcel build --target worker lib/paths-cache-worker.js",
-    "dev.main": "cross-env NODE_ENV=development parcel watch --target main lib/autocomplete-paths.js",
-    "build.main": "cross-env NODE_ENV=production parcel build --target main lib/autocomplete-paths.js",
-    "build": "npm run build.main",
+    "dev": "cross-env NODE_ENV=development parcel watch --target main lib/autocomplete-paths.js",
+    "build": "cross-env NODE_ENV=production parcel build --target main lib/autocomplete-paths.js",
     "build-commit": "build-commit -o dist",
     "prepare": "npm run build"
   },
@@ -32,12 +30,6 @@
         "zadeh": false
       },
       "outputFormat": "commonjs",
-      "isLibrary": true
-    },
-    "worker": {
-      "context": "web-worker",
-      "includeNodeModules": true,
-      "outputFormat": "global",
       "isLibrary": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "git-ignore-parser": "^0.0.2",
+    "fast-glob": "^3.2.5",
     "minimatch": "^3.0.4",
     "slash": "^3.0.0",
     "underscore": "^1.12.0",
@@ -44,6 +44,7 @@
     "@babel/cli": "^7.13.0",
     "@babel/core": "^7.13.8",
     "@types/minimatch": "^3.0.3",
+    "@types/node": "^14.14.31",
     "@types/underscore": "^1.11.0",
     "babel-preset-atomic": "^3.0.2",
     "build-commit": "0.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,7 @@
 dependencies:
   fast-glob: 3.2.5
+  is-glob: 4.0.1
+  is-valid-path: 0.1.1
   minimatch: 3.0.4
   slash: 3.0.0
   underscore: 1.12.0
@@ -7,6 +9,7 @@ dependencies:
 devDependencies:
   '@babel/cli': 7.13.0_@babel+core@7.13.8
   '@babel/core': 7.13.8
+  '@types/is-valid-path': 0.1.0
   '@types/minimatch': 3.0.3
   '@types/node': 14.14.31
   '@types/underscore': 1.11.0
@@ -3164,6 +3167,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==
+  /@types/is-valid-path/0.1.0:
+    dev: true
+    resolution:
+      integrity: sha512-2ontWtpN8O2nf5S7EjDDJ0DwrRa2t7wmS3Wmo322yWYG6yFBYC1QCaLhz4Iz+mzJy8Kf4zP5yVyEd1ANPDmOFQ==
   /@types/json-schema/7.0.7:
     dev: true
     resolution:
@@ -6400,6 +6407,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
+  /is-extglob/1.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
   /is-extglob/2.1.1:
     engines:
       node: '>=0.10.0'
@@ -6417,6 +6430,14 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==
+  /is-glob/2.0.1:
+    dependencies:
+      is-extglob: 1.0.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   /is-glob/3.1.0:
     dependencies:
       is-extglob: 2.1.1
@@ -6447,6 +6468,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+  /is-invalid-path/0.1.0:
+    dependencies:
+      is-glob: 2.0.1
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=
   /is-nan/1.3.2:
     dependencies:
       call-bind: 1.0.2
@@ -6570,6 +6599,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+  /is-valid-path/0.1.1:
+    dependencies:
+      is-invalid-path: 0.1.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=
   /is-windows/1.0.2:
     dev: true
     engines:
@@ -9666,6 +9703,7 @@ packages:
 specifiers:
   '@babel/cli': ^7.13.0
   '@babel/core': ^7.13.8
+  '@types/is-valid-path': ^0.1.0
   '@types/minimatch': ^3.0.3
   '@types/node': ^14.14.31
   '@types/underscore': ^1.11.0
@@ -9675,6 +9713,8 @@ specifiers:
   eslint: ^7.21.0
   eslint-config-atomic: ^1.11.0
   fast-glob: ^3.2.5
+  is-glob: ^4.0.1
+  is-valid-path: ^0.1.1
   minimatch: ^3.0.4
   parcel: 2.0.0-nightly.476
   prettier: ^2.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  git-ignore-parser: 0.0.2
+  fast-glob: 3.2.5
   minimatch: 3.0.4
   slash: 3.0.0
   underscore: 1.12.0
@@ -8,6 +8,7 @@ devDependencies:
   '@babel/cli': 7.13.0_@babel+core@7.13.8
   '@babel/core': 7.13.8
   '@types/minimatch': 3.0.3
+  '@types/node': 14.14.31
   '@types/underscore': 1.11.0
   babel-preset-atomic: 3.0.2_15bb487226806791f4ad2ae65749831c
   build-commit: 0.1.4
@@ -2197,14 +2198,12 @@ packages:
   /@nodelib/fs.scandir/2.1.4:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
-      run-parallel: 1.1.10
-    dev: true
+      run-parallel: 1.2.0
     engines:
       node: '>= 8'
     resolution:
       integrity: sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
   /@nodelib/fs.stat/2.0.4:
-    dev: true
     engines:
       node: '>= 8'
     resolution:
@@ -2212,8 +2211,7 @@ packages:
   /@nodelib/fs.walk/1.2.6:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
-      fastq: 1.10.1
-    dev: true
+      fastq: 1.11.0
     engines:
       node: '>= 8'
     resolution:
@@ -3182,6 +3180,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
+  /@types/node/14.14.31:
+    dev: true
+    resolution:
+      integrity: sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
   /@types/parse-json/4.0.0:
     dev: true
     resolution:
@@ -3900,7 +3902,6 @@ packages:
   /braces/3.0.2:
     dependencies:
       fill-range: 7.0.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -5601,7 +5602,6 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.2
       picomatch: 2.2.2
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -5628,12 +5628,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
-  /fastq/1.10.1:
+  /fastq/1.11.0:
     dependencies:
       reusify: 1.0.4
-    dev: true
     resolution:
-      integrity: sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==
+      integrity: sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   /fault/1.0.4:
     dependencies:
       format: 0.2.2
@@ -5680,7 +5679,6 @@ packages:
   /fill-range/7.0.1:
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -5838,12 +5836,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
-  /git-ignore-parser/0.0.2:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha1-fykXBKrv9mlvmHePzLJ2AbtzOTI=
   /glob-parent/3.1.0:
     dependencies:
       is-glob: 3.1.0
@@ -5855,7 +5847,6 @@ packages:
   /glob-parent/5.1.1:
     dependencies:
       is-glob: 4.0.1
-    dev: true
     engines:
       node: '>= 6'
     resolution:
@@ -6410,7 +6401,6 @@ packages:
     resolution:
       integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   /is-extglob/2.1.1:
-    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -6439,7 +6429,6 @@ packages:
   /is-glob/4.0.1:
     dependencies:
       is-extglob: 2.1.1
-    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -6482,7 +6471,6 @@ packages:
     resolution:
       integrity: sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   /is-number/7.0.0:
-    dev: true
     engines:
       node: '>=0.12.0'
     resolution:
@@ -7034,7 +7022,6 @@ packages:
     resolution:
       integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
   /merge2/1.4.1:
-    dev: true
     engines:
       node: '>= 8'
     resolution:
@@ -7063,7 +7050,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.2
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -7646,7 +7632,6 @@ packages:
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
   /picomatch/2.2.2:
-    dev: true
     engines:
       node: '>=8.6'
     resolution:
@@ -8217,6 +8202,9 @@ packages:
       node: '>=0.4.x'
     resolution:
       integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+  /queue-microtask/1.2.2:
+    resolution:
+      integrity: sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
   /randombytes/2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -8529,7 +8517,6 @@ packages:
     resolution:
       integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
   /reusify/1.0.4:
-    dev: true
     engines:
       iojs: '>=1.0.0'
       node: '>=0.10.0'
@@ -8557,10 +8544,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  /run-parallel/1.1.10:
-    dev: true
+  /run-parallel/1.2.0:
+    dependencies:
+      queue-microtask: 1.2.2
     resolution:
-      integrity: sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
+      integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   /rxjs/6.6.3:
     dependencies:
       tslib: 1.14.1
@@ -9210,7 +9198,6 @@ packages:
   /to-regex-range/5.0.1:
     dependencies:
       is-number: 7.0.0
-    dev: true
     engines:
       node: '>=8.0'
     resolution:
@@ -9680,13 +9667,14 @@ specifiers:
   '@babel/cli': ^7.13.0
   '@babel/core': ^7.13.8
   '@types/minimatch': ^3.0.3
+  '@types/node': ^14.14.31
   '@types/underscore': ^1.11.0
   babel-preset-atomic: ^3.0.2
   build-commit: 0.1.4
   cross-env: 7.0.3
   eslint: ^7.21.0
   eslint-config-atomic: ^1.11.0
-  git-ignore-parser: ^0.0.2
+  fast-glob: ^3.2.5
   minimatch: ^3.0.4
   parcel: 2.0.0-nightly.476
   prettier: ^2.2.1

--- a/typings/git-ignore-parser/index.d.ts
+++ b/typings/git-ignore-parser/index.d.ts
@@ -1,3 +1,0 @@
-declare module "git-ignore-parser" {
-  export default function parser(input: string): Array<string>
-}


### PR DESCRIPTION
### Description
- Build the path cache asynchronously without blocking the main thread -> Big projects no longer freeze Atom
- Build the cache in parallel (fast-glob uses threads underneath)
- Unified method for building the cache on all platforms
- Allows using glob for pattern ignoring which is the most common way of writing path patterns

### Fixed Issues

This fixes many issues. The following list is among them
fixes #254
fixes #231
fixes #221
fixes #164
fixes #204
fixes #205
fixes #219
fixes #157
fixes #186 

### Closes Pull requests
closes #245
closes #247

### Performance Verification
Now we can cache huge projects like DefinitelyTyped
https://github.com/DefinitelyTyped/DefinitelyTyped