### PR TITLE
Faster autocomplete list showing

### DIFF
--- a/lib/autocomplete-paths.js
+++ b/lib/autocomplete-paths.js
@@ -21,6 +21,7 @@ export function activate() {
     })
   )
 
+  // TODO should we use separate observers for each config?
   const cacheOptions = [
     "core.ignoredNames",
     "core.excludeVcsIgnoredPaths",
@@ -48,6 +49,16 @@ export function activate() {
       atom.config.observe(scopeOption, () => {
         if (!_provider) return
         _provider.reloadScopes()
+      })
+    )
+  })
+
+  const pathsProviderConfigs = ["autocomplete-paths.normalizeSlashes", "autocomplete-paths.suggestionPriority"]
+  pathsProviderConfigs.forEach((pathsProviderConfig) => {
+    subscriptions.add(
+      atom.config.observe(pathsProviderConfig, () => {
+        if (!_provider) return
+        _provider.updateConfig()
       })
     )
   })

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -59,9 +59,10 @@ export default class PathsCache extends EventEmitter {
    * @return {String[]}
    */
   getFilePathsForProjectDirectory(projectDirectory, relativeToPath = null) {
-    let filePaths = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
+    /** @type {Array<string>} */
+    const filePaths = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
     if (relativeToPath) {
-      return filePaths.filter((filePath) => filePath.indexOf(relativeToPath) === 0)
+      return filePaths.filter((filePath) => filePath.startsWith(relativeToPath))
     }
     return filePaths
   }

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -55,10 +55,10 @@ export default class PathsCache extends EventEmitter {
   /**
    * Returns the file paths for the given project directory with the given (optional) relative path
    * @param  {Directory} projectDirectory
-   * @param  {String} [relativeToPath=null]
+   * @param  {string} [relativeToPath=undefined]
    * @return {String[]}
    */
-  getFilePathsForProjectDirectory(projectDirectory, relativeToPath = null) {
+  getFilePathsForProjectDirectory(projectDirectory, relativeToPath = undefined) {
     /** @type {Array<string>} */
     const filePaths = this._filePathsByProjectDirectory.get(projectDirectory.path) || []
     if (relativeToPath) {

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -13,6 +13,7 @@ export default class PathsProvider extends EventEmitter {
   constructor() {
     super()
     this.reloadScopes()
+    this.updateConfig()
 
     this._pathsCache = new PathsCache()
     this._isReady = false
@@ -22,6 +23,13 @@ export default class PathsProvider extends EventEmitter {
 
     this._pathsCache.on("rebuild-cache", this._onRebuildCache)
     this._pathsCache.on("rebuild-cache-done", this._onRebuildCacheDone)
+  }
+
+  updateConfig() {
+    this.config = {
+      normalizeSlashes: atom.config.get("autocomplete-paths.normalizeSlashes"),
+      suggestionPriority: atom.config.get("autocomplete-paths.suggestionPriority"),
+    }
   }
 
   /**
@@ -141,20 +149,18 @@ export default class PathsProvider extends EventEmitter {
     }
 
     let suggestions = files.map((pathName) => {
-      const normalizeSlashes = atom.config.get("autocomplete-paths.normalizeSlashes")
-
       const projectRelativePath = atom.project.relativizePath(pathName)[1]
       let displayText = projectRelativePath
       if (directoryGiven) {
         displayText = path.relative(requestedDirectoryPath, pathName)
       }
-      if (normalizeSlashes) {
+      if (this.config.normalizeSlashes) {
         displayText = slash(displayText)
       }
 
       // Relativize path to current file if necessary
       let relativePath = path.relative(path.dirname(request.editor.getPath()), pathName)
-      if (normalizeSlashes) relativePath = slash(relativePath)
+      if (this.config.normalizeSlashes) relativePath = slash(relativePath)
       if (scope.relative !== false) {
         pathName = relativePath
         if (scope.includeCurrentDirectory !== false) {
@@ -255,7 +261,7 @@ export default class PathsProvider extends EventEmitter {
   }
 
   get suggestionPriority() {
-    return atom.config.get("autocomplete-paths.suggestionPriority")
+    return this.config.suggestionPriority
   }
 
   get fileCount() {

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -122,9 +122,10 @@ export default class PathsProvider extends EventEmitter {
 
     const requestedDirectoryPath = path.resolve(currentDirectory, parsedPathPrefix.dir)
 
-    let files = directoryGiven
-      ? this._pathsCache.getFilePathsForProjectDirectory(projectDirectory, requestedDirectoryPath)
-      : this._pathsCache.getFilePathsForProjectDirectory(projectDirectory)
+    let files = this._pathsCache.getFilePathsForProjectDirectory(
+      projectDirectory,
+      directoryGiven ? requestedDirectoryPath : undefined
+    )
 
     const fuzzyMatcher = directoryGiven ? parsedPathPrefix.base : pathPrefix
 

--- a/lib/paths-provider.js
+++ b/lib/paths-provider.js
@@ -127,14 +127,13 @@ export default class PathsProvider extends EventEmitter {
       directoryGiven ? requestedDirectoryPath : undefined
     )
 
-    const fuzzyMatcher = directoryGiven ? parsedPathPrefix.base : pathPrefix
-
     const { extensions } = scope
     if (extensions) {
       const regex = new RegExp(`.(${extensions.join("|")})$`)
       files = files.filter((path) => regex.test(path))
     }
 
+    const fuzzyMatcher = directoryGiven ? parsedPathPrefix.base : pathPrefix
     if (fuzzyMatcher) {
       files = filter(files, fuzzyMatcher, {
         maxResults: 10,


### PR DESCRIPTION
WIP

Zadeh supports adding all the files to its cache using `ArrayFilterer` instead of calling `filter` every time. If we use `ArrayFilterer` searching will be faster
https://github.com/atom-community/zadeh#arrayfilterer

I'm also inclined to add the things like `prefix` (which is used as `relativeToPath` here) or `extention` filtering to Zadeh.


## Benchmarks to test:
Repo [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)
- Calling `filter` directly each time takes 25ms (type `import "something"`)
https://github.com/atom-community/autocomplete-paths/blob/1d6979f65db931430e2f077f119e5c8505db5f79/lib/paths-provider.js#L138

- Filtering extensions takes 7.5ms (type `import "something"`)
https://github.com/atom-community/autocomplete-paths/blob/1d6979f65db931430e2f077f119e5c8505db5f79/lib/paths-provider.js#L132-L135

- Filtering relativeToPath takes 7.7ms (type `import "./"`)
https://github.com/atom-community/autocomplete-paths/blob/1d6979f65db931430e2f077f119e5c8505db5f79/lib/paths-cache.js#L64

Other benchmarks:

Top to bottom
![image](https://user-images.githubusercontent.com/16418197/110019341-f71e8d00-7ced-11eb-93c7-bd1d845f5865.png)



<details>
<summary>Bottom to top</summary>

![image](https://user-images.githubusercontent.com/16418197/110018533-ffc29380-7cec-11eb-92ab-b8f8558a5592.png)

![image](https://user-images.githubusercontent.com/16418197/110018830-5a5bef80-7ced-11eb-8fa2-3b1b895f4061.png)

![image](https://user-images.githubusercontent.com/16418197/110018927-78295480-7ced-11eb-876c-0327163e91b6.png)

![image](https://user-images.githubusercontent.com/16418197/110019058-9ee78b00-7ced-11eb-8f84-ea7239fcc17e.png)


</details>