### PR TITLE
fix: skip tracking the changes if maxFileCount is hit

### DIFF
--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -3,7 +3,7 @@ import { EventEmitter } from "events"
 import minimatch from "minimatch"
 import { Directory, File } from "atom"
 import { dirname, basename } from "path"
-import { union } from "./utils"
+import { union, dedent } from "./utils"
 import { globifyPath, globifyDirectory, globifyGitIgnoreFile } from "globify-gitignore"
 import glob from "fast-glob"
 import * as chokidar from "chokidar"
@@ -175,6 +175,15 @@ export default class PathsCache extends EventEmitter {
     }
     // add a watcher to run `this._onDirectoryChanged`
     const projectPath = projectDirectory.getPath()
+    if (this._filePathsByProjectDirectory.get(projectPath).length >= this.config.maxFileCount) {
+      console.warn(dedent`autocomplete-paths: Maximum file count of ${this.config.maxFileCount} has been exceeded,
+        so the subequent changes in the project are not tracked.
+        See these link to learn more:
+        https://github.com/atom-community/autocomplete-paths/wiki/Troubleshooting#maximum-file-limit-exceeded
+        https://github.com/atom-community/autocomplete-paths/issues/270
+      `)
+      return
+    }
     const ignored = this._allIgnoredGlobByDirectory.get(projectDirectory.path)
     // TODO smarter handling of directory changes
     // TODO get paths from the watcher itself

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,3 +26,8 @@ export function union(arr1: Array<any>, arr2: Array<any>) {
   merge(arr1, arr2)
   return unique(arr1)
 }
+
+/** @params {Array<string>} str */
+export function dedent(str) {
+  return String(str).replace(/(\n)\s+/g, "$1")
+}


### PR DESCRIPTION
Until we fix #270, we should skip tracking the changes in very large projects. This fixes the freezing that happens in large projects.