### PR TITLE
feat: add setting to not follow symlinks

### DIFF
--- a/lib/autocomplete-paths.js
+++ b/lib/autocomplete-paths.js
@@ -27,6 +27,7 @@ export function activate() {
   const cacheOptions = [
     "core.ignoredNames",
     "core.excludeVcsIgnoredPaths",
+    "autocomplete-paths.followSymlinks",
     "autocomplete-paths.ignoreSubmodules",
     "autocomplete-paths.ignoredNames",
     "autocomplete-paths.ignoredPatterns",

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -19,6 +19,11 @@ export const config = {
       "Suggestion priority of this provider. If set to a number larger than or equal to 1, suggestions will be displayed on top of default suggestions.",
     default: 2,
   },
+  followSymlinks: {
+    type: "boolean",
+    default: false,
+    description: "Follow directory symlinks. Disable if you have a self-referencing symlink.",
+  },
   ignoredNames: {
     type: "boolean",
     default: true,

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -35,6 +35,7 @@ export default class PathsCache extends EventEmitter {
       ignoredNames: atom.config.get("core.ignoredNames"),
       ignoredPatterns: atom.config.get("autocomplete-paths.ignoredPatterns"),
       maxFileCount: atom.config.get("autocomplete-paths.maxFileCount"),
+      followSymlinks: atom.config.get("autocomplete-paths.followSymlinks"),
     }
   }
 
@@ -192,7 +193,7 @@ export default class PathsCache extends EventEmitter {
       .watch([projectPath, ...ignored], {
         persistent: true,
         ignoreInitial: true, // do not run the listeners on the initial scan
-        followSymlinks: false,
+        followSymlinks: this.config.followSymlinks,
         interval: 1000,
         binaryInterval: 1000,
       })
@@ -467,7 +468,7 @@ export default class PathsCache extends EventEmitter {
           cwd: rootDirectory,
           onlyFiles: true,
           absolute: true,
-          followSymbolicLinks: false,
+          followSymbolicLinks: this.config.followSymlinks,
         }
       )
       return (
@@ -505,7 +506,7 @@ export default class PathsCache extends EventEmitter {
         dot: true,
         cwd: directoryPath,
         onlyFiles: true,
-        followSymbolicLinks: false,
+        followSymbolicLinks: this.config.followSymlinks,
       }
     )
     this._filePathsByProjectDirectory.set(directoryPath, files)

--- a/lib/paths-cache.js
+++ b/lib/paths-cache.js
@@ -467,6 +467,7 @@ export default class PathsCache extends EventEmitter {
           cwd: rootDirectory,
           onlyFiles: true,
           absolute: true,
+          followSymbolicLinks: false,
         }
       )
       return (
@@ -504,6 +505,7 @@ export default class PathsCache extends EventEmitter {
         dot: true,
         cwd: directoryPath,
         onlyFiles: true,
+        followSymbolicLinks: false,
       }
     )
     this._filePathsByProjectDirectory.set(directoryPath, files)


### PR DESCRIPTION
#256 Uses fast-glob, but it follows symlink by default [fast-glob#followsymboliclinks](https://github.com/mrmlnc/fast-glob#followsymboliclinks) 
This toggles the option to false, as it causes "Rebuilding paths cache" to never finish with a self-referencing symlink

Edit:
IgnorePatterns are passed to fast-glob with negative pattern
But node_modules folder is still followed (the self-referencing symlink)
Despite having "node_modules" in IgnoreNames, IgnorePatterns, and gitignore
Maybe consider the option  [mrmlnc/fast-glob#ignore](https://github.com/mrmlnc/fast-glob#ignore)? (don't know if that works)